### PR TITLE
Remove NextJS stuff from frontend-ts.yml

### DIFF
--- a/.github/workflows/frontend-ts.yml
+++ b/.github/workflows/frontend-ts.yml
@@ -13,18 +13,6 @@ jobs:
         with:
           cache: "yarn"
 
-      # https://nextjs.org/docs/advanced-features/ci-build-caching
-      - name: Cache NextJS Files
-        uses: actions/cache@v3
-        with:
-          path: |
-            ${{ github.workspace }}/frontend/.next/cache
-          # Generate a new cache whenever packages or source files change.
-          key: ${{ runner.os }}-nextjs-${{ hashFiles('**/yarn.lock') }}-${{ hashFiles('**.[jt]s', '**.[jt]sx') }}
-          # If source files changed but packages didn't, rebuild from a prior cache.
-          restore-keys: |
-            ${{ runner.os }}-nextjs-${{ hashFiles('**/yarn.lock') }}-
-
       - name: Install JS Dependencies
         run: yarn install --frozen-lockfile
 


### PR DESCRIPTION
Since checking the typescript can be done independently of NextJS, the cache step is unnecessary.