### PR TITLE
remove release channels from config

### DIFF
--- a/backend/cmd/cli/cli.go
+++ b/backend/cmd/cli/cli.go
@@ -33,7 +33,7 @@ var (
 func showUsageFooter() {
 	fmt.Fprintf(os.Stderr, "\n")
 
-	releaseChannel, _ := config.GetReleaseChannel()
+	releaseChannel := config.GetReleaseChannel()
 	fmt.Fprintf(
 		os.Stderr,
 		"robin %s on %s\n\n",

--- a/backend/cmd/cli/version.go
+++ b/backend/cmd/cli/version.go
@@ -3,7 +3,6 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 	"runtime"
 
 	"github.com/spf13/pflag"
@@ -27,18 +26,9 @@ func (c *VersionCommand) Parse(flagSet *pflag.FlagSet, args []string) error {
 func (c *VersionCommand) Run() error {
 	versionInfo := map[string]string{
 		"version": config.GetRobinVersion(),
+		"channel": string(config.GetReleaseChannel()),
 		"os":      runtime.GOOS,
 		"arch":    runtime.GOARCH,
-	}
-
-	if _, err := config.GetProjectPath(); err != nil {
-		fmt.Fprintf(os.Stderr, "WARN: Not in a robin project, cannot determine release channel\n")
-	} else {
-		releaseChannel, err := config.GetReleaseChannel()
-		if err != nil {
-			return fmt.Errorf("failed to get release channel: %w", err)
-		}
-		versionInfo["channel"] = string(releaseChannel)
 	}
 
 	buf, err := json.MarshalIndent(versionInfo, "", "\t")

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -78,9 +78,6 @@ func GetProjectAlias() (string, error) {
 }
 
 type RobinConfig struct {
-	// ReleaseChannel is the release channel to use for upgrades
-	ReleaseChannel ReleaseChannel `json:"releaseChannel"`
-
 	// Environments is a map of environment names to a map of environment variables
 	Environments map[string]map[string]string `json:"environments"`
 
@@ -98,7 +95,6 @@ type RobinConfig struct {
 }
 
 var defaultRobinConfig = RobinConfig{
-	ReleaseChannel:         ReleaseChannelStable,
 	MinifyExtensionClients: true,
 	EnableKeyMappings:      true,
 }

--- a/backend/internal/config/version_dev.go
+++ b/backend/internal/config/version_dev.go
@@ -6,6 +6,6 @@ func GetRobinVersion() string {
 	return "v0.0.0"
 }
 
-func GetReleaseChannel() (ReleaseChannel, error) {
-	return ReleaseChannelDev, nil
+func GetReleaseChannel() ReleaseChannel {
+	return ReleaseChannelDev
 }

--- a/backend/internal/config/version_prod.go
+++ b/backend/internal/config/version_prod.go
@@ -2,18 +2,33 @@
 
 package config
 
+import (
+	"fmt"
+)
+
 // robinVersion is the version of the running robin instance. The value is set
 // by the go linker during the build process.
 var robinVersion string
+
+// builtReleaseChannel is the release channel that the robin binary was built
+// for. The value is set by the go linker during the build process.
+var builtReleaseChannel string
+var activeReleaseChannel ReleaseChannel
+
+func init() {
+	if robinVersion == "" || builtReleaseChannel == "" {
+		panic("robinVersion and activeReleaseChannel must be set by the go linker")
+	}
+
+	if err := activeReleaseChannel.Parse(builtReleaseChannel); err != nil {
+		panic(fmt.Errorf("robin compiled with invalid release channel: %w", err))
+	}
+}
 
 func GetRobinVersion() string {
 	return robinVersion
 }
 
-func GetReleaseChannel() (ReleaseChannel, error) {
-	projectConfig, err := LoadProjectConfig()
-	if err != nil {
-		return ReleaseChannelStable, err
-	}
-	return projectConfig.ReleaseChannel, nil
+func GetReleaseChannel() ReleaseChannel {
+	return activeReleaseChannel
 }

--- a/backend/internal/log/logging.go
+++ b/backend/internal/log/logging.go
@@ -17,9 +17,7 @@ import (
 var writer io.Writer
 
 func init() {
-	// If we fail to get a release channel, we are defaulting to
-	// the stable channel anyways, so select that for logging too
-	channel, _ := config.GetReleaseChannel()
+	channel := config.GetReleaseChannel()
 
 	writer = &lumberjack.Logger{
 		Filename:   path.Join(channel.GetPath(), "logs.db"),

--- a/backend/scripts/release.sh
+++ b/backend/scripts/release.sh
@@ -90,12 +90,12 @@ for platform in darwin linux windows; do
         GOOS=$platform GOARCH=$arch go build \
             -o "${platformDir}/bin/robin${ext}" \
             -tags prod \
-            -ldflags "-X robinplatform.dev/internal/config.robinVersion=${ROBIN_VERSION}" \
+            -ldflags "-X robinplatform.dev/internal/config.robinVersion=${ROBIN_VERSION} -X robinplatform.dev/internal/config.builtReleaseChannel=${TARGET_CHANNEL}" \
             ./cmd/cli
         GOOS=$platform GOARCH=$arch go build \
             -o "${platformDir}/bin/robin-upgrade${ext}" \
             -tags prod \
-            -ldflags "-X robinplatform.dev/internal/config.robinVersion=${ROBIN_VERSION}" \
+            -ldflags "-X robinplatform.dev/internal/config.robinVersion=${ROBIN_VERSION} -X robinplatform.dev/internal/config.builtReleaseChannel=${TARGET_CHANNEL}" \
             ./cmd/upgrade
 
         cd "${platformDir}"

--- a/frontend/components/AppWindow.tsx
+++ b/frontend/components/AppWindow.tsx
@@ -61,13 +61,15 @@ export function AppWindow({ id, setTitle }: Props) {
 	return (
 		<div className={'full col'}>
 			{error && (
-				<div style={{ width: '100%', padding: '1rem', }}>
-					<Alert variant='error' title={`The '${id}' app has crashed.`}>
-						<pre style={{marginBottom:'1rem'}}>
+				<div style={{ width: '100%', padding: '1rem' }}>
+					<Alert variant="error" title={`The '${id}' app has crashed.`}>
+						<pre style={{ marginBottom: '1rem' }}>
 							<code>{error}</code>
 						</pre>
 
-						<Button variant='primary' onClick={() => setError(null)}>Reload app</Button>
+						<Button variant="primary" onClick={() => setError(null)}>
+							Reload app
+						</Button>
 					</Alert>
 				</div>
 			)}

--- a/toolkit/src/react.tsx
+++ b/toolkit/src/react.tsx
@@ -2,8 +2,5 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 
 export function renderApp(children: React.ReactNode) {
-	ReactDOM.render(
-		<>{children}</>,
-		document.getElementById('root'),
-	);
+	ReactDOM.render(<>{children}</>, document.getElementById('root'));
 }


### PR DESCRIPTION
Now that release channels are suffixed binaries, we don't need them in the config. Instead, the release channel is baked into the binary by the linker.