### PR TITLE
feat: http caching

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,0 +1,3 @@
+*.pprof
+*.test
+

--- a/backend/cmd/cli/start.go
+++ b/backend/cmd/cli/start.go
@@ -14,6 +14,7 @@ import (
 type StartCommand struct {
 	port               int
 	bindAddress        string
+	enablePprof        bool
 	forceStableToolkit bool
 }
 
@@ -28,6 +29,7 @@ func (cmd *StartCommand) Description() string {
 func (cmd *StartCommand) Parse(flagSet *flag.FlagSet, args []string) error {
 	flagSet.IntVar(&cmd.port, "port", 9010, "The port to listen on")
 	flagSet.StringVar(&cmd.bindAddress, "bind", "[::1]", "The address to bind to")
+	flagSet.BoolVar(&cmd.enablePprof, "pprof", false, "Enable pprof endpoints")
 
 	if config.GetReleaseChannel() != config.ReleaseChannelStable {
 		flagSet.BoolVar(&cmd.forceStableToolkit, "use-stable-toolkit", false, "Force the use of the stable toolkit")
@@ -56,6 +58,7 @@ func (cmd *StartCommand) Run() error {
 	app := server.Server{
 		BindAddress: cmd.bindAddress,
 		Port:        cmd.port,
+		EnablePprof: cmd.enablePprof || releaseChannel == config.ReleaseChannelDev,
 	}
 	return app.Run()
 }

--- a/backend/internal/compile/app_config.go
+++ b/backend/internal/compile/app_config.go
@@ -109,9 +109,6 @@ func (appConfig *RobinAppConfig) readRobinAppConfig(configPath string) error {
 	if appConfig.ConfigPath.Scheme != "file" && appConfig.ConfigPath.Scheme != "https" {
 		return fmt.Errorf("invalid config path scheme '%s' (only file and https are supported)", appConfig.ConfigPath.Scheme)
 	}
-	if appConfig.ConfigPath.Scheme == "https" && appConfig.ConfigPath.Host != "esm.sh" {
-		return fmt.Errorf("cannot load file from host '%s' (only esm.sh is supported)", appConfig.ConfigPath.Host)
-	}
 
 	// All paths must end with `robin.app.json`
 	if path.Base(appConfig.ConfigPath.Path) != "robin.app.json" {

--- a/backend/internal/compile/client.html
+++ b/backend/internal/compile/client.html
@@ -32,6 +32,8 @@
 				);
 			});
 		</script>
-		<script src="{{.ScriptURL}}"></script>
+		<script>
+			{{.ScriptSource}}
+		</script>
 	</body>
 </html>

--- a/backend/internal/compile/compiler.go
+++ b/backend/internal/compile/compiler.go
@@ -27,7 +27,7 @@ var (
 
 	logger log.Logger = log.New("compile")
 
-	cacheEnabled = os.Getenv("ROBIN_CACHE") != "false"
+	CacheEnabled = os.Getenv("ROBIN_CACHE") != "false"
 )
 
 type Compiler struct {
@@ -70,7 +70,7 @@ func (compiler *Compiler) GetApp(id string) (CompiledApp, error) {
 		return app, nil
 	}
 
-	if compiler.appCache == nil && cacheEnabled {
+	if compiler.appCache == nil && CacheEnabled {
 		compiler.appCache = make(map[string]CompiledApp)
 	}
 

--- a/backend/internal/compile/compiler.go
+++ b/backend/internal/compile/compiler.go
@@ -79,19 +79,10 @@ func (compiler *Compiler) GetApp(id string) (CompiledApp, error) {
 		return CompiledApp{}, fmt.Errorf("failed to load app config: %w", err)
 	}
 
-	htmlOutput := bytes.NewBuffer(nil)
-	if err := clientHtmlTemplate.Execute(htmlOutput, map[string]any{
-		"AppConfig": appConfig,
-		"ScriptURL": fmt.Sprintf("/api/app-resources/%s/bootstrap.js", id),
-	}); err != nil {
-		return CompiledApp{}, fmt.Errorf("failed to render client html: %w", err)
-	}
-
 	app := CompiledApp{
 		compiler: compiler,
 
 		Id:     id,
-		Html:   htmlOutput.String(),
 		Cached: true,
 	}
 	if err := app.buildClientJs(); err != nil {
@@ -100,6 +91,15 @@ func (compiler *Compiler) GetApp(id string) (CompiledApp, error) {
 	if err := app.buildServerBundle(); err != nil {
 		return CompiledApp{}, err
 	}
+
+	htmlOutput := bytes.NewBuffer(nil)
+	if err := clientHtmlTemplate.Execute(htmlOutput, map[string]any{
+		"AppConfig":    appConfig,
+		"ScriptSource": app.ClientJs,
+	}); err != nil {
+		return CompiledApp{}, fmt.Errorf("failed to render client html: %w", err)
+	}
+	app.Html = htmlOutput.String()
 
 	if compiler.appCache != nil {
 		compiler.appCache[id] = app

--- a/backend/internal/compile/css.go
+++ b/backend/internal/compile/css.go
@@ -99,7 +99,7 @@ func buildSass(srcPath, sass string) (string, error) {
 	result := es.Build(es.BuildOptions{
 		Stdin: &es.StdinOptions{
 			Contents: fmt.Sprintf(`
-				import sass from 'https://esm.sh/sass@1.58.3?bundle&target=esnext'
+				import sass from 'https://esm.sh/sass@1.58.3'
 
 				let style = document.createElement('style')
 				style.setAttribute('data-path', '%s')

--- a/backend/internal/compile/plugins.go
+++ b/backend/internal/compile/plugins.go
@@ -186,11 +186,12 @@ var esbuildPluginLoadHttp = es.Plugin{
 				targetUrl.RawQuery += "target=esnext"
 			}
 
-			str, _, err := httpClient.Get(args.Path)
+			res, err := httpClient.Get(args.Path)
 			if err != nil {
 				return es.OnLoadResult{}, fmt.Errorf("failed to load %s: %w", args.Path, err)
 			}
 
+			str := res.Body
 			if strings.HasSuffix(targetUrl.Path, ".css") {
 				str = wrapWithCssLoader(args.Path, str)
 			}
@@ -202,8 +203,8 @@ var esbuildPluginLoadHttp = es.Plugin{
 		})
 
 		build.OnEnd(func(_ *es.BuildResult) (es.OnEndResult, error) {
-			err := httpClient.Save()
-			return es.OnEndResult{}, err
+			go httpClient.Save()
+			return es.OnEndResult{}, nil
 		})
 	},
 }

--- a/backend/internal/compile/plugins.go
+++ b/backend/internal/compile/plugins.go
@@ -11,6 +11,7 @@ import (
 	"robinplatform.dev/internal/compile/resolve"
 	"robinplatform.dev/internal/config"
 	"robinplatform.dev/internal/httpcache"
+	"robinplatform.dev/internal/log"
 )
 
 var httpClient httpcache.CacheClient
@@ -20,9 +21,14 @@ func init() {
 	robinPath := config.GetRobinPath()
 
 	var err error
-	httpClient, err = httpcache.NewClient(filepath.Join(robinPath, "http-cache.json"), 1024*1024*1024)
+	cacheFilename := filepath.Join(robinPath, "http-cache.json")
+	httpClient, err = httpcache.NewClient(cacheFilename, 1024*1024*1024)
 	if err != nil {
-		panic(fmt.Errorf("failed to initialize HTTP client: %w", err))
+		httpLogger := log.New("http")
+		httpLogger.Debug("Failed to load HTTP cache, will recreate", log.Ctx{
+			"error": err,
+			"path":  cacheFilename,
+		})
 	}
 
 	esmSHResolver = resolve.NewHttpResolver(&url.URL{

--- a/backend/internal/compile/resolve/http.go
+++ b/backend/internal/compile/resolve/http.go
@@ -89,7 +89,7 @@ func (hfs *HttpResolverFs) Open(filename string) (fs.File, error) {
 	//
 	// However, we will skip node builtin polyfills, which are hosted on `esm.sh`, but don't exist
 	// on `unpkg.com`.
-	if fileUrl.Scheme == "https" && fileUrl.Host == "esm.sh" && !strings.ContainsRune(fileUrl.Path[1:], '/') {
+	if fileUrl.Scheme == "https" && fileUrl.Host == "esm.sh" && !strings.HasPrefix(fileUrl.Path, "/node_") {
 		_, err := hfs.client.Get(fmt.Sprintf("https://unpkg.com%s", fileUrl.Path))
 		if err != nil {
 			return nil, err

--- a/backend/internal/compile/resolve/http.go
+++ b/backend/internal/compile/resolve/http.go
@@ -86,13 +86,13 @@ func (hfs *HttpResolverFs) Open(filename string) (fs.File, error) {
 	// unpkg.com also realizes that the URL is actually immutable, and will ask the client to cache
 	// it while esm.sh reports the response as 'no-cache'.
 	if fileUrl.Scheme == "https" && fileUrl.Host == "esm.sh" {
-		_, _, err := hfs.client.Get(fmt.Sprintf("https://unpkg.com%s", fileUrl.Path))
+		_, err := hfs.client.Get(fmt.Sprintf("https://unpkg.com%s", fileUrl.Path))
 		if err != nil {
 			return nil, err
 		}
 	}
 
-	contents, _, err := hfs.client.Get(fileUrl.String())
+	res, err := hfs.client.Get(fileUrl.String())
 
 	// TODO: return a fs.ErrNotExist if the status code is 404
 	if err != nil {
@@ -101,6 +101,6 @@ func (hfs *HttpResolverFs) Open(filename string) (fs.File, error) {
 
 	return HttpFileEntry{
 		path:     filename,
-		contents: contents,
+		contents: res.Body,
 	}, nil
 }

--- a/backend/internal/compile/resolve/resolve.go
+++ b/backend/internal/compile/resolve/resolve.go
@@ -87,6 +87,10 @@ func (resolver *Resolver) resolveModule(source, target string) (string, error) {
 	return "", fmt.Errorf("could not resolve: %s", target)
 }
 
+func (resolver *Resolver) ResetCache() {
+	resolver.resolveCache = nil
+}
+
 // ReadFile returns the contents of the file at the given path, if the file exists
 // at that exact filepath. If the file does not exist, it returns nil and false.
 // This is preferable to reading the file directly from the given FS, because during

--- a/backend/internal/compile/resolve/resolve_test.go
+++ b/backend/internal/compile/resolve/resolve_test.go
@@ -1,18 +1,25 @@
 package resolve
 
 import (
+	"net/url"
 	"path/filepath"
 	"testing"
 	"testing/fstest"
+
+	"robinplatform.dev/internal/httpcache"
 )
 
+type testHelper interface {
+	Fatalf(format string, args ...interface{})
+}
+
 type resolverTester struct {
-	t        *testing.T
+	t        testHelper
 	fs       map[string]*fstest.MapFile
 	resolver *Resolver
 }
 
-func createTester(t *testing.T, inputVfs map[string]*fstest.MapFile) resolverTester {
+func createTester[T testHelper](t T, inputVfs map[string]*fstest.MapFile) resolverTester {
 	vfs := make(map[string]*fstest.MapFile, len(inputVfs))
 
 	for key, value := range inputVfs {
@@ -132,4 +139,117 @@ func TestModuleFileResolvers(t *testing.T) {
 	tester.assertResolvedFrom("./src/foo.js", "bar", "node_modules/bar/index.js")
 	tester.assertResolvedFrom("./node_modules/bar/index.js", "./foo", "node_modules/bar/foo.js")
 	tester.assertResolvedFrom("./node_modules/bar/index.js", "lodash", "node_modules/bar/node_modules/lodash/index.js")
+}
+
+func BenchmarkVFSResolvers(b *testing.B) {
+	tester := createTester(b, map[string]*fstest.MapFile{
+		"src/index.js":              {},
+		"src/foo.js":                {},
+		"src/data.json":             {},
+		"node_modules/bar/index.js": {},
+		"node_modules/bar/foo.js":   {},
+		"node_modules/bar/node_modules/lodash/index.js": {},
+	})
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		// resolve relative path
+		tester.assertResolvedFrom("./src/foo.js", "./foo", "src/foo.js")
+		// resolve directory path
+		tester.assertResolvedFrom("./src/foo.js", "./", "src/index.js")
+		// resolve module
+		tester.assertResolvedFrom("./src/foo.js", "bar", "node_modules/bar/index.js")
+	}
+}
+
+func assertResolveFrom(b *testing.B, resolver *Resolver, from string, specifier string, expected string) {
+	b.Helper()
+	actual, err := resolver.ResolveFrom(from, specifier)
+	if err != nil {
+		b.Fatalf("Unexpected error: %s", err)
+	}
+	if actual != expected {
+		b.Fatalf("Expected %q but got %q", expected, actual)
+	}
+}
+
+func BenchmarkColdResolveAppExample(b *testing.B) {
+	httpClient, err := httpcache.NewClient("", 1024*1024*1024)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	resolver := NewHttpResolver(&url.URL{
+		Scheme: "https",
+		Host:   "esm.sh",
+	}, httpClient)
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		assertResolveFrom(b, resolver, "/@robinplatform/app-example@0.0.10/src/app.tsx", "./app.server", "@robinplatform/app-example@0.0.10/src/app.server.ts")
+		resolver.ResetCache()
+	}
+}
+
+func BenchmarkColdNoCacheResolveAppExample(b *testing.B) {
+	httpClient, err := httpcache.NewClient("", 0)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	resolver := NewHttpResolver(&url.URL{
+		Scheme: "https",
+		Host:   "esm.sh",
+	}, httpClient)
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		assertResolveFrom(b, resolver, "/@robinplatform/app-example@0.0.10/src/app.tsx", "./app.server", "@robinplatform/app-example@0.0.10/src/app.server.ts")
+		resolver.ResetCache()
+	}
+}
+
+func BenchmarkWarmResolveAppExample(b *testing.B) {
+	httpClient, err := httpcache.NewClient("", 1024*1024*1024)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	resolver := NewHttpResolver(&url.URL{
+		Scheme: "https",
+		Host:   "esm.sh",
+	}, httpClient)
+	assertResolveFrom(b, resolver, "/@robinplatform/app-example@0.0.10/src/app.tsx", "./app.server", "@robinplatform/app-example@0.0.10/src/app.server.ts")
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		assertResolveFrom(b, resolver, "/@robinplatform/app-example@0.0.10/src/app.tsx", "./app.server", "@robinplatform/app-example@0.0.10/src/app.server.ts")
+	}
+}
+
+func BenchmarkWarmNoCacheResolveAppExample(b *testing.B) {
+	httpClient, err := httpcache.NewClient("", 0)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	resolver := NewHttpResolver(&url.URL{
+		Scheme: "https",
+		Host:   "esm.sh",
+	}, httpClient)
+	assertResolveFrom(b, resolver, "/@robinplatform/app-example@0.0.10/src/app.tsx", "./app.server", "@robinplatform/app-example@0.0.10/src/app.server.ts")
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		assertResolveFrom(b, resolver, "/@robinplatform/app-example@0.0.10/src/app.tsx", "./app.server", "@robinplatform/app-example@0.0.10/src/app.server.ts")
+	}
 }

--- a/backend/internal/httpcache/client.go
+++ b/backend/internal/httpcache/client.go
@@ -1,0 +1,152 @@
+package httpcache
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"robinplatform.dev/internal/log"
+)
+
+type CacheClient struct {
+	cache  Cache
+	client *http.Client
+}
+
+func NewClient(filename string, maxSize int) (CacheClient, error) {
+	cache, err := New(filename, maxSize)
+	if err != nil {
+		return CacheClient{}, err
+	}
+
+	client := &CacheClient{
+		cache:  cache,
+		client: &http.Client{},
+	}
+	return *client, nil
+}
+
+// parseCacheControl will attempt to parse the given `Cache-Control` header and
+// extract a deadline for the cache entry, as well as a bool indicating whether the
+// entry should be cached.
+//
+// A nil deadline indicates that the entry is immutable, and can be cached forever.
+//
+// This method will only attempt to parse the `max-age` directive, and ignore all other
+// directives.
+func parseCacheControl(cacheControl string) (*time.Duration, bool) {
+	if cacheControl == "" {
+		return nil, false
+	}
+
+	if strings.Contains(cacheControl, "immutable") {
+		return nil, true
+	}
+
+	maxAgeStart := strings.Index(cacheControl, "max-age=")
+	if maxAgeStart == -1 {
+		return nil, false
+	}
+
+	maxAgeStart += len("max-age=")
+	if cacheControl[maxAgeStart] == '"' {
+		maxAgeStart++
+	}
+
+	maxAgeEnd := len(cacheControl)
+	for i := maxAgeStart; i < len(cacheControl); i++ {
+		if cacheControl[i] == ',' || cacheControl[i] == '"' {
+			maxAgeEnd = i
+			break
+		}
+	}
+
+	maxAge, err := strconv.ParseInt(cacheControl[maxAgeStart:maxAgeEnd], 10, 64)
+	if err != nil {
+		logger.Warn("Failed to parse cache-control", log.Ctx{
+			"cacheControl": cacheControl,
+			"err":          err,
+			"maxAgeValue":  cacheControl[maxAgeStart:maxAgeEnd],
+		})
+		return nil, false
+	}
+	if maxAge <= 0 {
+		return nil, false
+	}
+
+	duration := time.Duration(maxAge) * time.Second
+	return &duration, true
+}
+
+// parseAge will attempt to parse the given `Age` header and extract the elapsed duration
+func parseAge(age string) time.Duration {
+	if age == "" {
+		return 0 * time.Second
+	}
+
+	elapsedSecs, err := strconv.ParseInt(age, 10, 64)
+	if err != nil {
+		logger.Warn("Failed to parse age header", log.Ctx{
+			"age": age,
+			"err": err,
+		})
+		return 0 * time.Second
+	}
+	if elapsedSecs <= 0 {
+		return 0 * time.Second
+	}
+
+	return time.Duration(elapsedSecs) * time.Second
+}
+
+func (client *CacheClient) Get(targetUrl string) (string, bool, error) {
+	if value, ok := client.cache.Get(targetUrl); ok {
+		return value, true, nil
+	}
+
+	resp, err := client.client.Get(targetUrl)
+	if err != nil {
+		return "", false, err
+	}
+	defer resp.Body.Close()
+
+	buf, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", false, err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return "", false, fmt.Errorf("failed to get %s: %s", targetUrl, string(buf))
+	}
+
+	cacheControl := resp.Header.Get("Cache-Control")
+	maxAge, shouldCache := parseCacheControl(cacheControl)
+	if !shouldCache {
+		logger.Debug("HTTP resource is not cacheable", log.Ctx{
+			"targetUrl":    targetUrl,
+			"cacheControl": cacheControl,
+		})
+		return string(buf), false, nil
+	}
+
+	var ttl *time.Duration
+	if maxAge != nil {
+		age := parseAge(resp.Header.Get("Age"))
+		ttlLocal := *maxAge - age
+		ttl = &ttlLocal
+	}
+
+	client.cache.Set(targetUrl, string(buf), ttl)
+	return string(buf), false, nil
+}
+
+func (client *CacheClient) GetCacheSize() int {
+	return client.cache.GetSize()
+}
+
+func (client *CacheClient) Save() error {
+	return client.cache.Save()
+}

--- a/backend/internal/httpcache/httpcache.go
+++ b/backend/internal/httpcache/httpcache.go
@@ -14,10 +14,11 @@ import (
 
 var logger = log.New("http")
 
-type cacheEntry struct {
-	Value    string
-	Deadline *time.Time
-	LastUsed *int64
+type CacheEntry struct {
+	StatusCode int
+	Value      string
+	Deadline   *int64
+	LastUsed   *int64
 }
 
 type httpCache struct {
@@ -26,25 +27,27 @@ type httpCache struct {
 	maxSize  int
 
 	Size   int
-	Values map[string]*cacheEntry
+	Values map[string]*CacheEntry
 }
 
 type Cache interface {
 	Delete(string)
-	Get(string) (string, bool)
-	Set(string, string, *time.Duration)
+	Get(string) (CacheEntry, bool)
+	Set(string, CacheEntry)
 	GetSize() int
 	Save() error
 }
 
+// New creates a new cache with the given filename. If the filename is non-empty, it will
+// attempt to load the cache from disk. If this fails, the cache will still be usable but will
+// return with an error.
 func New(filename string, maxSize int) (Cache, error) {
 	cache := &httpCache{
 		filename: filename,
 		mux:      &sync.RWMutex{},
 		maxSize:  maxSize,
-		Values:   make(map[string]*cacheEntry),
+		Values:   make(map[string]*CacheEntry),
 	}
-	fmt.Printf("cache max size: %d\n", maxSize)
 	return cache, cache.open()
 }
 
@@ -133,31 +136,31 @@ func (cache *httpCache) Delete(key string) {
 	cache.mux.Unlock()
 }
 
-func (cache *httpCache) Get(key string) (string, bool) {
+func (cache *httpCache) Get(key string) (CacheEntry, bool) {
 	cache.mux.RLock()
 	node, ok := cache.Values[key]
 	cache.mux.RUnlock()
 
 	if ok {
 		// If the entry has expired, delete and pretend it wasn't found
-		if node.Deadline != nil && node.Deadline.Before(time.Now()) {
+		if node.Deadline != nil && *node.Deadline < time.Now().UnixNano() {
 			cache.Delete(key)
-			return "", false
+			return CacheEntry{}, false
 		}
 
 		atomic.StoreInt64(node.LastUsed, time.Now().UnixNano())
-		return node.Value, true
+		return *node, true
 	}
 
-	return "", false
+	return CacheEntry{}, false
 }
 
-func (cache *httpCache) Set(key, value string, ttl *time.Duration) {
+func (cache *httpCache) Set(key string, entry CacheEntry) {
 	// do not allow single resources that are larger than the cache
-	if len(value) >= cache.maxSize {
+	if len(entry.Value) >= cache.maxSize {
 		logger.Debug("Refusing to cache large resource", log.Ctx{
 			"url":  key,
-			"size": len(value),
+			"size": len(entry.Value),
 			"max":  cache.maxSize,
 		})
 		return
@@ -169,27 +172,20 @@ func (cache *httpCache) Set(key, value string, ttl *time.Duration) {
 	cache.delete(key)
 
 	lastUsed := int64(time.Now().UnixNano())
-	node := &cacheEntry{
-		Value:    value,
-		LastUsed: &lastUsed,
-	}
-	if ttl != nil {
-		deadline := time.Now().Add(*ttl)
-		node.Deadline = &deadline
-	}
+	entry.LastUsed = &lastUsed
 
-	cache.Values[key] = node
-	cache.Size += len(value)
+	cache.Values[key] = &entry
+	cache.Size += len(entry.Value)
 
 	logger.Debug("Added to cache", log.Ctx{
 		"url":              key,
-		"size":             len(value),
+		"size":             len(entry.Value),
 		"updatedCacheSize": cache.Size,
 	})
 
 	for cache.Size > cache.maxSize && len(cache.Values) > 1 {
 		var lastUsedKey string
-		var lastUsedEntry *cacheEntry
+		var lastUsedEntry *CacheEntry
 		for key, node := range cache.Values {
 			if lastUsedEntry == nil || *node.LastUsed < *lastUsedEntry.LastUsed {
 				lastUsedKey = key

--- a/backend/internal/httpcache/httpcache.go
+++ b/backend/internal/httpcache/httpcache.go
@@ -1,0 +1,193 @@
+package httpcache
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"robinplatform.dev/internal/log"
+)
+
+var logger = log.New("http")
+
+type cacheEntry struct {
+	Value    string
+	Deadline *time.Time
+	LastUsed *int64
+}
+
+type httpCache struct {
+	filename string
+	mux      *sync.RWMutex
+
+	MaxSize int
+	Size    int
+	Values  map[string]*cacheEntry
+}
+
+type Cache interface {
+	Delete(string)
+	Get(string) (string, bool)
+	Set(string, string, *time.Duration)
+	GetSize() int
+	Save() error
+}
+
+func New(filename string, maxSize int) (Cache, error) {
+	cache := &httpCache{
+		filename: filename,
+		mux:      &sync.RWMutex{},
+		MaxSize:  maxSize,
+		Values:   make(map[string]*cacheEntry),
+	}
+	return cache, cache.open()
+}
+
+func (cache *httpCache) open() error {
+	cache.mux.Lock()
+	defer cache.mux.Unlock()
+
+	if cache.filename == "" {
+		return nil
+	}
+
+	file, err := os.Open(cache.filename)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("failed to open cache from %s: %w", cache.filename, err)
+	}
+
+	buf, err := io.ReadAll(file)
+	if err != nil {
+		return fmt.Errorf("failed to read cache from %s: %w", cache.filename, err)
+	}
+
+	if err := json.Unmarshal(buf, cache); err != nil {
+		return fmt.Errorf("failed to unmarshal cache from %s: %w", cache.filename, err)
+	}
+
+	return nil
+}
+
+func (cache *httpCache) Save() error {
+	if cache.filename == "" {
+		return fmt.Errorf("cannot save cache without a filename")
+	}
+
+	cache.mux.RLock()
+	defer cache.mux.RUnlock()
+
+	file, err := os.Create(cache.filename)
+	if err != nil {
+		return fmt.Errorf("failed to create cache in %s: %w", cache.filename, err)
+	}
+	defer file.Close()
+
+	buf, err := json.Marshal(cache)
+	if err != nil {
+		return fmt.Errorf("failed to marshal cache to %s: %w", cache.filename, err)
+	}
+
+	if _, err := file.Write(buf); err != nil {
+		return fmt.Errorf("failed to write cache to %s: %w", cache.filename, err)
+	}
+
+	return nil
+}
+
+func (cache *httpCache) GetSize() int {
+	return cache.Size
+}
+
+// delete performs a delete of the given cache entry. This method must be called with a write
+// lock on the cache.
+func (cache *httpCache) delete(key string) {
+	if node, ok := cache.Values[key]; ok {
+		logger.Debug("Removing from cache", log.Ctx{
+			"url":      key,
+			"size":     len(node.Value),
+			"lastUsed": time.Unix(0, *node.LastUsed).String(),
+		})
+		cache.Size -= len(node.Value)
+		delete(cache.Values, key)
+	}
+}
+
+func (cache *httpCache) Delete(key string) {
+	cache.mux.Lock()
+	cache.delete(key)
+	cache.mux.Unlock()
+}
+
+func (cache *httpCache) Get(key string) (string, bool) {
+	cache.mux.RLock()
+	node, ok := cache.Values[key]
+	cache.mux.RUnlock()
+
+	if ok {
+		// If the entry has expired, delete and pretend it wasn't found
+		if node.Deadline != nil && node.Deadline.Before(time.Now()) {
+			cache.Delete(key)
+			return "", false
+		}
+
+		atomic.StoreInt64(node.LastUsed, time.Now().UnixNano())
+		return node.Value, true
+	}
+
+	return "", false
+}
+
+func (cache *httpCache) Set(key, value string, ttl *time.Duration) {
+	// do not allow single resources that are larger than the cache
+	if len(value) >= cache.MaxSize {
+		logger.Debug("Refusing to cache large resource", log.Ctx{
+			"url":  key,
+			"size": len(value),
+		})
+		return
+	}
+
+	cache.mux.Lock()
+	defer cache.mux.Unlock()
+
+	cache.delete(key)
+
+	lastUsed := int64(time.Now().UnixNano())
+	node := &cacheEntry{
+		Value:    value,
+		LastUsed: &lastUsed,
+	}
+	if ttl != nil {
+		deadline := time.Now().Add(*ttl)
+		node.Deadline = &deadline
+	}
+
+	cache.Values[key] = node
+	cache.Size += len(value)
+
+	logger.Debug("Added to cache", log.Ctx{
+		"url":              key,
+		"size":             len(value),
+		"updatedCacheSize": cache.Size,
+	})
+
+	for cache.Size > cache.MaxSize && len(cache.Values) > 1 {
+		var lastUsedKey string
+		var lastUsedEntry *cacheEntry
+		for key, node := range cache.Values {
+			if lastUsedEntry == nil || *node.LastUsed < *lastUsedEntry.LastUsed {
+				lastUsedKey = key
+				lastUsedEntry = node
+			}
+		}
+
+		cache.delete(lastUsedKey)
+	}
+}

--- a/backend/internal/httpcache/httpcache_test.go
+++ b/backend/internal/httpcache/httpcache_test.go
@@ -1,0 +1,384 @@
+package httpcache
+
+import (
+	"crypto/rand"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func ptr[T any](d T) *T {
+	return &d
+}
+
+func assertCacheControl(t *testing.T, value string, expectedDeadline *time.Duration, expectedShouldCache bool) {
+	deadline, shouldCache := parseCacheControl(value)
+
+	expectedDeadlineStr := ""
+	if expectedDeadline != nil {
+		expectedDeadlineStr = expectedDeadline.Truncate(time.Second).String()
+	}
+
+	deadlineStr := ""
+	if deadline != nil {
+		deadlineStr = deadline.Truncate(time.Second).String()
+	}
+
+	if deadlineStr != expectedDeadlineStr || shouldCache != expectedShouldCache {
+		t.Fatalf("unexpected parsed cache control: %s, %v (expected %s, %v)", deadlineStr, shouldCache, expectedDeadlineStr, expectedShouldCache)
+	}
+}
+
+func TestParseCacheControl(t *testing.T) {
+	assertCacheControl(t, "", nil, false)
+	assertCacheControl(t, "no-cache", nil, false)
+	assertCacheControl(t, "max-age=0", nil, false)
+	assertCacheControl(t, "max-age=1000", ptr(1000*time.Second), true)
+	assertCacheControl(t, "max-age=1000, must-revalidate", ptr(1000*time.Second), true)
+}
+
+func TestHttpCache(t *testing.T) {
+	server := http.Server{}
+	server.Addr = ":0"
+	server.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/immutable":
+			w.Header().Set("Cache-Control", "immutable")
+		case "/1s":
+			w.Header().Set("Cache-Control", "max-age=2")
+		}
+
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("Hello, world!"))
+	})
+
+	listener, err := net.Listen("tcp", server.Addr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	go server.Serve(listener)
+
+	client, err := NewClient("", 10*1000)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	{
+		res, fromCache, err := client.Get(fmt.Sprintf("http://%s/1s", listener.Addr().String()))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if res != "Hello, world!" {
+			t.Fatalf("unexpected response: %s", res)
+		}
+		if fromCache {
+			t.Fatalf("unexpected cache hit")
+		}
+
+		// re-fetch from cache immediately
+		res, fromCache, err = client.Get(fmt.Sprintf("http://%s/1s", listener.Addr().String()))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if res != "Hello, world!" {
+			t.Fatalf("unexpected response: %s", res)
+		}
+		if !fromCache {
+			t.Logf("%#v\n", client.cache)
+			t.Fatalf("unexpected cache miss")
+		}
+
+		// wait for cache to expire
+		time.Sleep(3 * time.Second)
+
+		// re-fetch from server
+		res, fromCache, err = client.Get(fmt.Sprintf("http://%s/1s", listener.Addr().String()))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if res != "Hello, world!" {
+			t.Fatalf("unexpected response: %s", res)
+		}
+
+		if fromCache {
+			t.Fatalf("unexpected cache hit")
+		}
+	}
+
+	{
+		// load immutable resource, should get cached
+		res, fromCache, err := client.Get(fmt.Sprintf("http://%s/immutable", listener.Addr().String()))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if res != "Hello, world!" {
+			t.Fatalf("unexpected response: %s", res)
+		}
+		if fromCache {
+			t.Fatalf("unexpected cache hit")
+		}
+
+		// close the server, so we can test that the cache is still valid
+		server.Close()
+		listener.Close()
+
+		// re-fetch from cache
+		res, fromCache, err = client.Get(fmt.Sprintf("http://%s/immutable", listener.Addr().String()))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if res != "Hello, world!" {
+			t.Fatalf("unexpected response: %s", res)
+		}
+		if !fromCache {
+			t.Fatalf("unexpected cache miss")
+		}
+	}
+}
+
+func TestHttpCacheMaxSize(t *testing.T) {
+	// identify temporary location to store cache
+	tmpDir := os.TempDir()
+	tmpHash := make([]byte, 8)
+	rand.Read(tmpHash)
+	tmpCacheFile := filepath.Join(tmpDir, fmt.Sprintf("httpcache_test_%x", tmpHash))
+	defer os.Remove(tmpCacheFile)
+
+	// start server to test against
+	server := http.Server{}
+	server.Addr = ":0"
+	server.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Cache-Control", "immutable")
+		w.WriteHeader(http.StatusOK)
+
+		// we will always return 1000 byte responses
+		w.Write([]byte(strings.Repeat("a", 1000)))
+	})
+
+	listener, err := net.Listen("tcp", server.Addr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	go server.Serve(listener)
+
+	// this client can store up to 10 responses
+	client, err := NewClient(tmpCacheFile, 10*1000)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// verify that cache file does not exist
+	if _, err := os.Stat(tmpCacheFile); err == nil {
+		t.Fatalf("cache file should not exist")
+	} else if !os.IsNotExist(err) {
+		t.Fatal(err)
+	}
+
+	// make 10 requests, which should all be cached
+	for i := 0; i < 10; i++ {
+		res, fromCache, err := client.Get(fmt.Sprintf("http://%s/%d", listener.Addr().String(), i))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if len(res) != 1000 {
+			t.Fatalf("unexpected response: %s", res)
+		}
+		if fromCache {
+			t.Fatalf("unexpected cache hit")
+		}
+	}
+
+	// save cache, and reopen
+	if err := client.Save(); err != nil {
+		t.Fatal(err)
+	}
+
+	client, err = NewClient(tmpCacheFile, 10*1000)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// re-fetch all 10, should all hit the cache
+	for i := 0; i < 10; i++ {
+		res, fromCache, err := client.Get(fmt.Sprintf("http://%s/%d", listener.Addr().String(), i))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if len(res) != 1000 {
+			t.Fatalf("unexpected response: %s", res)
+		}
+		if !fromCache {
+			t.Fatalf("unexpected cache miss")
+		}
+
+		// small delay to make sure that the order of the cache is preserved
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	// make one more request, which should immediately cause the first request
+	// to get bumped out of the cache
+	{
+		res, fromCache, err := client.Get(fmt.Sprintf("http://%s/10", listener.Addr().String()))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if len(res) != 1000 {
+			t.Fatalf("unexpected response: %s", res)
+		}
+		if fromCache {
+			t.Fatalf("unexpected cache hit")
+		}
+	}
+
+	// check first request again
+	{
+		res, fromCache, err := client.Get(fmt.Sprintf("http://%s/0", listener.Addr().String()))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if len(res) != 1000 {
+			t.Fatalf("unexpected response: %s", res)
+		}
+
+		if fromCache {
+			t.Fatalf("unexpected cache hit")
+		}
+	}
+
+	// save cache, and reopen
+	if err := client.Save(); err != nil {
+		t.Fatal(err)
+	}
+
+	client, err = NewClient(tmpCacheFile, 10*1000)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// make sure that the cache size is adjusted
+	if cacheSize := client.GetCacheSize(); cacheSize > 10*1000 {
+		t.Fatalf("unexpected cache size: %d", cacheSize)
+	}
+
+	// read cache by hand, for debugging
+	{
+		fd, err := os.Open(tmpCacheFile)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		buf, err := io.ReadAll(fd)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		t.Logf("Persisted cache file: %s\n", tmpCacheFile)
+		t.Logf("Persisted cache size: %d\n", len(buf))
+	}
+}
+
+func TestHttpCacheWithPersistedDeadline(t *testing.T) {
+	tmpDir := os.TempDir()
+	tmpHash := make([]byte, 8)
+	rand.Read(tmpHash)
+	tmpCacheFile := filepath.Join(tmpDir, fmt.Sprintf("httpcache_test_%x", tmpHash))
+	defer os.Remove(tmpCacheFile)
+
+	// start server to test against
+	server := http.Server{}
+	server.Addr = ":0"
+	server.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Cache-Control", "max-age=2")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("Hello, world!"))
+	})
+
+	listener, err := net.Listen("tcp", server.Addr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	go server.Serve(listener)
+
+	// create a client that can store up to 10 responses
+	client, err := NewClient(tmpCacheFile, 10*1000)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// run a single request to cache it
+	{
+		res, fromCache, err := client.Get(fmt.Sprintf("http://%s/", listener.Addr().String()))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if string(res) != "Hello, world!" {
+			t.Fatalf("unexpected response: %s", res)
+		}
+
+		if fromCache {
+			t.Fatalf("unexpected cache hit")
+		}
+	}
+
+	//  make sure the value is in the cache
+	{
+		res, fromCache, err := client.Get(fmt.Sprintf("http://%s/", listener.Addr().String()))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if string(res) != "Hello, world!" {
+			t.Fatalf("unexpected response: %s", res)
+		}
+
+		if !fromCache {
+			t.Fatalf("unexpected cache miss")
+		}
+	}
+
+	// save the cache
+	if err := client.Save(); err != nil {
+		t.Fatal(err)
+	}
+
+	// wait for the cache to expire
+	time.Sleep(3 * time.Second)
+
+	// reload the cache
+	client, err = NewClient(tmpCacheFile, 10*1000)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// re-run the request, which should be a cache miss
+	{
+		res, fromCache, err := client.Get(fmt.Sprintf("http://%s/", listener.Addr().String()))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if string(res) != "Hello, world!" {
+			t.Fatalf("unexpected response: %s", res)
+		}
+
+		if fromCache {
+			t.Fatalf("unexpected cache hit")
+		}
+	}
+}

--- a/backend/internal/httpcache/httpcache_test.go
+++ b/backend/internal/httpcache/httpcache_test.go
@@ -145,6 +145,18 @@ func TestHttpCache(t *testing.T) {
 			t.Fatalf("unexpected cache miss")
 		}
 	}
+
+	// HEAD request should succeed, even though the server is not running
+	{
+		exists, err := client.Head(fmt.Sprintf("http://%s/immutable", listener.Addr().String()))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if !exists {
+			t.Fatalf("unexpected HEAD response (expected resouce to exist)")
+		}
+	}
 }
 
 func TestHttpCacheMaxSize(t *testing.T) {

--- a/backend/internal/httpcache/httpcache_test.go
+++ b/backend/internal/httpcache/httpcache_test.go
@@ -71,28 +71,28 @@ func TestHttpCache(t *testing.T) {
 	}
 
 	{
-		res, fromCache, err := client.Get(fmt.Sprintf("http://%s/1s", listener.Addr().String()))
+		res, err := client.Get(fmt.Sprintf("http://%s/1s", listener.Addr().String()))
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		if res != "Hello, world!" {
-			t.Fatalf("unexpected response: %s", res)
+		if res.Body != "Hello, world!" {
+			t.Fatalf("unexpected response: %s", res.Body)
 		}
-		if fromCache {
+		if res.FromCache {
 			t.Fatalf("unexpected cache hit")
 		}
 
 		// re-fetch from cache immediately
-		res, fromCache, err = client.Get(fmt.Sprintf("http://%s/1s", listener.Addr().String()))
+		res, err = client.Get(fmt.Sprintf("http://%s/1s", listener.Addr().String()))
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		if res != "Hello, world!" {
-			t.Fatalf("unexpected response: %s", res)
+		if res.Body != "Hello, world!" {
+			t.Fatalf("unexpected response: %s", res.Body)
 		}
-		if !fromCache {
+		if !res.FromCache {
 			t.Logf("%#v\n", client.cache)
 			t.Fatalf("unexpected cache miss")
 		}
@@ -101,31 +101,30 @@ func TestHttpCache(t *testing.T) {
 		time.Sleep(3 * time.Second)
 
 		// re-fetch from server
-		res, fromCache, err = client.Get(fmt.Sprintf("http://%s/1s", listener.Addr().String()))
+		res, err = client.Get(fmt.Sprintf("http://%s/1s", listener.Addr().String()))
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		if res != "Hello, world!" {
-			t.Fatalf("unexpected response: %s", res)
+		if res.Body != "Hello, world!" {
+			t.Fatalf("unexpected response: %s", res.Body)
 		}
-
-		if fromCache {
+		if res.FromCache {
 			t.Fatalf("unexpected cache hit")
 		}
 	}
 
 	{
 		// load immutable resource, should get cached
-		res, fromCache, err := client.Get(fmt.Sprintf("http://%s/immutable", listener.Addr().String()))
+		res, err := client.Get(fmt.Sprintf("http://%s/immutable", listener.Addr().String()))
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		if res != "Hello, world!" {
-			t.Fatalf("unexpected response: %s", res)
+		if res.Body != "Hello, world!" {
+			t.Fatalf("unexpected response: %s", res.Body)
 		}
-		if fromCache {
+		if res.FromCache {
 			t.Fatalf("unexpected cache hit")
 		}
 
@@ -134,15 +133,15 @@ func TestHttpCache(t *testing.T) {
 		listener.Close()
 
 		// re-fetch from cache
-		res, fromCache, err = client.Get(fmt.Sprintf("http://%s/immutable", listener.Addr().String()))
+		res, err = client.Get(fmt.Sprintf("http://%s/immutable", listener.Addr().String()))
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		if res != "Hello, world!" {
-			t.Fatalf("unexpected response: %s", res)
+		if res.Body != "Hello, world!" {
+			t.Fatalf("unexpected response: %s", res.Body)
 		}
-		if !fromCache {
+		if !res.FromCache {
 			t.Fatalf("unexpected cache miss")
 		}
 	}
@@ -200,15 +199,15 @@ func TestHttpCacheMaxSize(t *testing.T) {
 
 	// make 10 requests, which should all be cached
 	for i := 0; i < 10; i++ {
-		res, fromCache, err := client.Get(fmt.Sprintf("http://%s/%d", listener.Addr().String(), i))
+		res, err := client.Get(fmt.Sprintf("http://%s/%d", listener.Addr().String(), i))
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		if len(res) != 1000 {
-			t.Fatalf("unexpected response: %s", res)
+		if len(res.Body) != 1000 {
+			t.Fatalf("unexpected response: %s", res.Body)
 		}
-		if fromCache {
+		if res.FromCache {
 			t.Fatalf("unexpected cache hit")
 		}
 	}
@@ -225,15 +224,15 @@ func TestHttpCacheMaxSize(t *testing.T) {
 
 	// re-fetch all 10, should all hit the cache
 	for i := 0; i < 10; i++ {
-		res, fromCache, err := client.Get(fmt.Sprintf("http://%s/%d", listener.Addr().String(), i))
+		res, err := client.Get(fmt.Sprintf("http://%s/%d", listener.Addr().String(), i))
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		if len(res) != 1000 {
-			t.Fatalf("unexpected response: %s", res)
+		if len(res.Body) != 1000 {
+			t.Fatalf("unexpected response: %s", res.Body)
 		}
-		if !fromCache {
+		if !res.FromCache {
 			t.Fatalf("unexpected cache miss")
 		}
 
@@ -244,31 +243,31 @@ func TestHttpCacheMaxSize(t *testing.T) {
 	// make one more request, which should immediately cause the first request
 	// to get bumped out of the cache
 	{
-		res, fromCache, err := client.Get(fmt.Sprintf("http://%s/10", listener.Addr().String()))
+		res, err := client.Get(fmt.Sprintf("http://%s/10", listener.Addr().String()))
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		if len(res) != 1000 {
-			t.Fatalf("unexpected response: %s", res)
+		if len(res.Body) != 1000 {
+			t.Fatalf("unexpected response: %s", res.Body)
 		}
-		if fromCache {
+		if res.FromCache {
 			t.Fatalf("unexpected cache hit")
 		}
 	}
 
 	// check first request again
 	{
-		res, fromCache, err := client.Get(fmt.Sprintf("http://%s/0", listener.Addr().String()))
+		res, err := client.Get(fmt.Sprintf("http://%s/0", listener.Addr().String()))
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		if len(res) != 1000 {
-			t.Fatalf("unexpected response: %s", res)
+		if len(res.Body) != 1000 {
+			t.Fatalf("unexpected response: %s", res.Body)
 		}
 
-		if fromCache {
+		if res.FromCache {
 			t.Fatalf("unexpected cache hit")
 		}
 	}
@@ -335,32 +334,31 @@ func TestHttpCacheWithPersistedDeadline(t *testing.T) {
 
 	// run a single request to cache it
 	{
-		res, fromCache, err := client.Get(fmt.Sprintf("http://%s/", listener.Addr().String()))
+		res, err := client.Get(fmt.Sprintf("http://%s/", listener.Addr().String()))
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		if string(res) != "Hello, world!" {
-			t.Fatalf("unexpected response: %s", res)
+		if res.Body != "Hello, world!" {
+			t.Fatalf("unexpected response: %s", res.Body)
 		}
 
-		if fromCache {
+		if res.FromCache {
 			t.Fatalf("unexpected cache hit")
 		}
 	}
 
 	//  make sure the value is in the cache
 	{
-		res, fromCache, err := client.Get(fmt.Sprintf("http://%s/", listener.Addr().String()))
+		res, err := client.Get(fmt.Sprintf("http://%s/", listener.Addr().String()))
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		if string(res) != "Hello, world!" {
-			t.Fatalf("unexpected response: %s", res)
+		if res.Body != "Hello, world!" {
+			t.Fatalf("unexpected response: %s", res.Body)
 		}
-
-		if !fromCache {
+		if !res.FromCache {
 			t.Fatalf("unexpected cache miss")
 		}
 	}
@@ -381,16 +379,15 @@ func TestHttpCacheWithPersistedDeadline(t *testing.T) {
 
 	// re-run the request, which should be a cache miss
 	{
-		res, fromCache, err := client.Get(fmt.Sprintf("http://%s/", listener.Addr().String()))
+		res, err := client.Get(fmt.Sprintf("http://%s/", listener.Addr().String()))
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		if string(res) != "Hello, world!" {
-			t.Fatalf("unexpected response: %s", res)
+		if res.Body != "Hello, world!" {
+			t.Fatalf("unexpected response: %s", res.Body)
 		}
-
-		if fromCache {
+		if res.FromCache {
 			t.Fatalf("unexpected cache hit")
 		}
 	}
@@ -424,15 +421,15 @@ func BenchmarkClientColdGet(b *testing.B) {
 	b.ReportAllocs()
 
 	for i := 0; i < b.N; i++ {
-		res, fromCache, err := client.Get(targetUrl + strconv.FormatInt(int64(i), 10))
+		res, err := client.Get(targetUrl + strconv.FormatInt(int64(i), 10))
 		if err != nil {
 			b.Fatal(err)
 		}
 
-		if len(res) != 1000 {
-			b.Fatalf("unexpected response: %s", res)
+		if len(res.Body) != 1000 {
+			b.Fatalf("unexpected response: %s", res.Body)
 		}
-		if fromCache {
+		if res.FromCache {
 			b.Fatalf("unexpected cache hit")
 		}
 	}
@@ -464,15 +461,15 @@ func BenchmarkClientWarmGet(b *testing.B) {
 	targetUrl := fmt.Sprintf("http://%s/test", listener.Addr().String())
 
 	{
-		res, fromCache, err := client.Get(targetUrl)
+		res, err := client.Get(targetUrl)
 		if err != nil {
 			b.Fatal(err)
 		}
 
-		if len(res) != 1000 {
-			b.Fatalf("unexpected response: %s", res)
+		if len(res.Body) != 1000 {
+			b.Fatalf("unexpected response: %s", res.Body)
 		}
-		if fromCache {
+		if res.FromCache {
 			b.Fatalf("unexpected cache hit")
 		}
 	}
@@ -484,15 +481,15 @@ func BenchmarkClientWarmGet(b *testing.B) {
 	b.ReportAllocs()
 
 	for i := 0; i < b.N; i++ {
-		res, fromCache, err := client.Get(targetUrl)
+		res, err := client.Get(targetUrl)
 		if err != nil {
 			b.Fatal(err)
 		}
 
-		if len(res) != 1000 {
-			b.Fatalf("unexpected response: %s", res)
+		if len(res.Body) != 1000 {
+			b.Fatalf("unexpected response: %s", res.Body)
 		}
-		if !fromCache {
+		if !res.FromCache {
 			b.Fatalf("unexpected cache miss")
 		}
 	}

--- a/backend/internal/server/server.go
+++ b/backend/internal/server/server.go
@@ -3,25 +3,27 @@ package server
 import (
 	"encoding/json"
 	"fmt"
+	"net"
 	"net/http"
+	"net/http/pprof"
 	"os"
 	"strings"
-	"time"
 
 	"github.com/julienschmidt/httprouter"
 	"robinplatform.dev/internal/compile"
 	"robinplatform.dev/internal/config"
-	"robinplatform.dev/internal/health"
 	"robinplatform.dev/internal/log"
 )
 
 type Server struct {
 	BindAddress string
 	Port        int
+	EnablePprof bool
 
-	router    *httprouter.Router
-	webRouter http.Handler
-	compiler  compile.Compiler
+	router      *httprouter.Router
+	pprofRouter http.Handler
+	webRouter   http.Handler
+	compiler    compile.Compiler
 }
 
 var logger log.Logger = log.New("server")
@@ -72,23 +74,18 @@ func (server *Server) loadRpcMethods() {
 }
 
 func createErrorJs(errMessage string) string {
-	errJson, err := json.Marshal(errMessage)
-	if err != nil {
-		errMessage = "Unknown error occurred"
-	} else {
-		errMessage = string(errJson)
-	}
-
 	return fmt.Sprintf(`
 		window.parent.postMessage({
 			type: 'appError',
-			error: %s,
+			error: %q,
 		}, '*')
 	`, errMessage)
 }
 
 func (server *Server) ServeHTTP(res http.ResponseWriter, req *http.Request) {
-	if strings.HasPrefix(req.URL.Path, "/api") {
+	if server.EnablePprof && strings.HasPrefix(req.URL.Path, "/debug/pprof/") {
+		server.pprofRouter.ServeHTTP(res, req)
+	} else if strings.HasPrefix(req.URL.Path, "/api") {
 		server.router.ServeHTTP(res, req)
 	} else {
 		server.webRouter.ServeHTTP(res, req)
@@ -106,6 +103,17 @@ func (server *Server) Run() error {
 		server.loadRoutes()
 	}
 	server.compiler.ServerPort = server.Port
+
+	if server.EnablePprof {
+		logger.Print("Running with pprof enabled", log.Ctx{})
+		mux := http.NewServeMux()
+		mux.Handle("/debug/pprof/", http.HandlerFunc(pprof.Index))
+		mux.Handle("/debug/pprof/cmdline", http.HandlerFunc(pprof.Cmdline))
+		mux.Handle("/debug/pprof/profile", http.HandlerFunc(pprof.Profile))
+		mux.Handle("/debug/pprof/symbol", http.HandlerFunc(pprof.Symbol))
+		mux.Handle("/debug/pprof/trace", http.HandlerFunc(pprof.Trace))
+		server.pprofRouter = mux
+	}
 
 	// Start precompiling apps, and ignore the errors for now
 	// The errors will get handled when the app is requested
@@ -179,14 +187,9 @@ func (server *Server) Run() error {
 
 		app, err := server.compiler.GetApp(id)
 		if err != nil {
-			serializedErr, err := json.Marshal(err.Error())
-			if err != nil {
-				serializedErr = []byte(`Unknown error occurred`)
-			}
-
 			res.Header().Set("Content-Type", "application/javascript; charset=utf-8")
 			res.WriteHeader(http.StatusInternalServerError)
-			res.Write([]byte(createErrorJs(string(serializedErr))))
+			res.Write([]byte(createErrorJs(err.Error())))
 			return
 		}
 
@@ -203,22 +206,17 @@ func (server *Server) Run() error {
 	server.loadRpcMethods()
 	portBinding := fmt.Sprintf("%s:%d", server.BindAddress, server.Port)
 
-	// TODO: Simplify this
-
 	fmt.Printf("Starting server ...\r")
-	go func() {
-		healthCheck := health.HttpHealthCheck{
-			Method: "GET",
-			Url:    fmt.Sprintf("http://%s", portBinding),
-		}
-		for !health.CheckHttp(healthCheck) {
-			time.Sleep(1 * time.Second)
-		}
-		logger.Print(fmt.Sprintf("Started robin server on http://%s", portBinding), log.Ctx{})
-	}()
 
-	if err := http.ListenAndServe(portBinding, server); err != nil {
+	listener, err := net.Listen("tcp", portBinding)
+	if err != nil {
 		return fmt.Errorf("failed to start server: %s", err)
 	}
+	logger.Print(fmt.Sprintf("Started robin server on http://%s", portBinding), log.Ctx{})
+
+	httpServer := http.Server{
+		Handler: server,
+	}
+	httpServer.Serve(listener)
 	return nil
 }

--- a/backend/internal/server/server.go
+++ b/backend/internal/server/server.go
@@ -118,13 +118,15 @@ func (server *Server) Run() error {
 	// Start precompiling apps, and ignore the errors for now
 	// The errors will get handled when the app is requested
 	go func() {
-		apps, err := compile.GetAllProjectApps()
-		if err != nil {
-			return
-		}
+		if compile.CacheEnabled {
+			apps, err := compile.GetAllProjectApps()
+			if err != nil {
+				return
+			}
 
-		for _, app := range apps {
-			go server.compiler.GetApp(app.Id)
+			for _, app := range apps {
+				go server.compiler.GetApp(app.Id)
+			}
 		}
 	}()
 


### PR DESCRIPTION
This implements an HTTP client that will (mostly) respect `Cache-Control` headers.

Architecture of the cache:

 * Cache is persisted to discuss in a JSON file
   * Deserialization does not seem to cause noticeable delay on startup (tested with ~6MB cache)
   * Serialization blocks esbuild (cache saving is done at the end of the esbuild pipeline), but the overall perf was unaffected even when this was done concurrently/skipped
 * Cache contains byte size, and a hashmap of URLs -> entries. Entries store a deadline (or nil for immutable), contents as string (esbuild takes a string pointer rather than a byte slice, so it was faster to just store as a string), and an int64ptr that holds the time of last use.
 * Retrieving a value from the cache causes the time of last use to be atomically updated (not fully atomic, since we generate and then write, but worst case, this causes a few nanosecs diff)
 * On retrieve, we delete the entry if it has passed its TTL
 * On save/flush, the cache performs a 'compaction' cycle, where it evicts all expired data and then finally deletes from the least recently used items until the cache reaches the desired size. It then flushes the cache to disk.

---

It significantly helps with #46, though does not fix it completely.

 * On main, cold loading `@robinplatform/app-example` takes around 22s.
   * 16.5s to render `base.html`
 * On httpcache, cold loading `@robinplatform/app-example` takes around 0.3s.
   * 150ms to render `base.html`
 * On either, cold loading `@robinplatform/app-example` from disk takes around 0.14s. (how on earth is this a different order of magnitude.........)
   * 70ms to render `base.html`