### PR TITLE
Make `config` a little less global

### DIFF
--- a/backend/cmd/cli/add.go
+++ b/backend/cmd/cli/add.go
@@ -44,11 +44,6 @@ var eraseEndLine = "\u001B[K"
 func (cmd *AddCommand) Run() error {
 	projectPath := config.GetProjectPathOrExit()
 
-	projectConfig := config.RobinProjectConfig{}
-	if err := projectConfig.LoadRobinProjectConfig(projectPath); err != nil {
-		return err
-	}
-
 	existingApps, err := compile.GetAllProjectApps()
 	if err != nil {
 		return fmt.Errorf("failed to get existing apps: %w", err)

--- a/backend/cmd/cli/add.go
+++ b/backend/cmd/cli/add.go
@@ -44,6 +44,11 @@ var eraseEndLine = "\u001B[K"
 func (cmd *AddCommand) Run() error {
 	projectPath := config.GetProjectPathOrExit()
 
+	projectConfig := config.RobinProjectConfig{}
+	if err := projectConfig.LoadRobinProjectConfig(projectPath); err != nil {
+		return err
+	}
+
 	existingApps, err := compile.GetAllProjectApps()
 	if err != nil {
 		return fmt.Errorf("failed to get existing apps: %w", err)
@@ -85,7 +90,7 @@ func (cmd *AddCommand) Run() error {
 		// makes changes, we don't force the user to pick between their changes and ours. Unlike
 		// certain programs. *cough* *cough* *npm* *cough* *cough*
 		projectConfig := config.RobinProjectConfig{}
-		if err := projectConfig.LoadRobinProjectConfig(); err != nil {
+		if err := projectConfig.LoadRobinProjectConfig(projectPath); err != nil {
 			return fmt.Errorf("failed to load project config: %w", err)
 		}
 

--- a/backend/cmd/cli/rm.go
+++ b/backend/cmd/cli/rm.go
@@ -40,10 +40,14 @@ func (cmd *RemoveCommand) Parse(flags *flag.FlagSet, args []string) error {
 
 func (cmd *RemoveCommand) Run() error {
 	projectPath := config.GetProjectPathOrExit()
+	projectConfig := config.RobinProjectConfig{}
+	if err := projectConfig.LoadRobinProjectConfig(projectPath); err != nil {
+		return err
+	}
 
 	apps, err := compile.GetAllProjectApps()
 	if err != nil {
-		return fmt.Errorf("failed to load project apps: %w", err)
+		return fmt.Errorf("failed to load project config: %w", err)
 	}
 
 	existingApps := make(map[string]compile.RobinAppConfig, len(apps)*3)
@@ -75,11 +79,6 @@ func (cmd *RemoveCommand) Run() error {
 				fmt.Printf("Not installed: %s\n", appConfig.Name)
 			}
 		}
-	}
-
-	projectConfig := config.RobinProjectConfig{}
-	if err := projectConfig.LoadRobinProjectConfig(); err != nil {
-		return fmt.Errorf("failed to load project config: %w", err)
 	}
 
 	newApps := make([]string, 0, len(projectConfig.Apps))

--- a/backend/cmd/cli/rm.go
+++ b/backend/cmd/cli/rm.go
@@ -41,13 +41,10 @@ func (cmd *RemoveCommand) Parse(flags *flag.FlagSet, args []string) error {
 func (cmd *RemoveCommand) Run() error {
 	projectPath := config.GetProjectPathOrExit()
 	projectConfig := config.RobinProjectConfig{}
-	if err := projectConfig.LoadRobinProjectConfig(projectPath); err != nil {
-		return err
-	}
 
 	apps, err := compile.GetAllProjectApps()
 	if err != nil {
-		return fmt.Errorf("failed to load project config: %w", err)
+		return fmt.Errorf("failed to load project apps: %w", err)
 	}
 
 	existingApps := make(map[string]compile.RobinAppConfig, len(apps)*3)
@@ -79,6 +76,10 @@ func (cmd *RemoveCommand) Run() error {
 				fmt.Printf("Not installed: %s\n", appConfig.Name)
 			}
 		}
+	}
+
+	if err := projectConfig.LoadRobinProjectConfig(projectPath); err != nil {
+		return fmt.Errorf("failed to load project config: %w", err)
 	}
 
 	newApps := make([]string, 0, len(projectConfig.Apps))

--- a/backend/cmd/cli/rm.go
+++ b/backend/cmd/cli/rm.go
@@ -40,7 +40,6 @@ func (cmd *RemoveCommand) Parse(flags *flag.FlagSet, args []string) error {
 
 func (cmd *RemoveCommand) Run() error {
 	projectPath := config.GetProjectPathOrExit()
-	projectConfig := config.RobinProjectConfig{}
 
 	apps, err := compile.GetAllProjectApps()
 	if err != nil {
@@ -78,6 +77,7 @@ func (cmd *RemoveCommand) Run() error {
 		}
 	}
 
+	projectConfig := config.RobinProjectConfig{}
 	if err := projectConfig.LoadRobinProjectConfig(projectPath); err != nil {
 		return fmt.Errorf("failed to load project config: %w", err)
 	}

--- a/backend/internal/compile/app_config.go
+++ b/backend/internal/compile/app_config.go
@@ -191,8 +191,13 @@ func (appConfig *RobinAppConfig) UpdateSettings(settings map[string]any) error {
 }
 
 func GetAllProjectApps() ([]RobinAppConfig, error) {
+	projectPath, err := config.GetProjectPath()
+	if err != nil {
+		return nil, err
+	}
+
 	projectConfig := config.RobinProjectConfig{}
-	if err := projectConfig.LoadRobinProjectConfig(); err != nil {
+	if err := projectConfig.LoadRobinProjectConfig(projectPath); err != nil {
 		return nil, err
 	}
 

--- a/backend/internal/config/config_test.go
+++ b/backend/internal/config/config_test.go
@@ -1,0 +1,53 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func createProjectStructure(projectPath string, paths map[string]string) error {
+	projectPath = filepath.FromSlash(projectPath)
+	for path, contents := range paths {
+		path = filepath.FromSlash(filepath.Join(projectPath, path))
+		if err := os.WriteFile(path, []byte(contents), 0755); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func TestConfigLoad(t *testing.T) {
+	projectPath := t.TempDir()
+	err := createProjectStructure(projectPath, map[string]string{
+		"robin.json": `{
+			"name": "robin",
+			"apps": ["app1", "app2"]
+		}`,
+	})
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var projectConfig RobinProjectConfig
+	if err := projectConfig.LoadRobinProjectConfig(projectPath); err != nil {
+		t.Fatal(err)
+	}
+
+	if projectConfig.Name != "robin" {
+		t.Errorf("Expected 'robin', got '%s'", projectConfig.Name)
+	}
+
+	expected := []string{"app1", "app2"}
+	if len(projectConfig.Apps) != len(expected) {
+		t.Errorf("Expected %d apps, got %d", len(expected), len(projectConfig.Apps))
+	}
+
+	for idx, appPath := range projectConfig.Apps {
+		if appPath != expected[idx] {
+			t.Errorf("Expected app %d to be '%s', got '%s'", idx, expected[idx], appPath)
+		}
+	}
+}

--- a/backend/internal/config/project_config.go
+++ b/backend/internal/config/project_config.go
@@ -8,19 +8,23 @@ import (
 )
 
 type RobinProjectConfig struct {
+	// Path to the project folder
+	ProjectPath string `json:"-"`
 	// Name of the app
 	Name string `json:"name,omitempty"`
 	// Apps to load for this project
 	Apps []string `json:"apps,omitempty"`
 }
 
-func (projectConfig *RobinProjectConfig) LoadRobinProjectConfig() error {
-	projectPath, err := GetProjectPath()
+func (projectConfig *RobinProjectConfig) LoadRobinProjectConfig(projectPath string) error {
+	var err error
+
+	projectConfig.ProjectPath, err = filepath.Abs(projectPath)
 	if err != nil {
 		return err
 	}
 
-	configPath := filepath.Join(projectPath, "robin.json")
+	configPath := filepath.Join(projectConfig.ProjectPath, "robin.json")
 
 	buf, err := os.ReadFile(configPath)
 	if err != nil {
@@ -36,12 +40,7 @@ func (projectConfig *RobinProjectConfig) LoadRobinProjectConfig() error {
 }
 
 func (projectConfig *RobinProjectConfig) SaveRobinProjectConfig() error {
-	projectPath, err := GetProjectPath()
-	if err != nil {
-		return err
-	}
-
-	configPath := filepath.Join(projectPath, "robin.json")
+	configPath := filepath.Join(projectConfig.ProjectPath, "robin.json")
 
 	// Let's indent the config so it is easily readable
 	buf, err := json.MarshalIndent(projectConfig, "", "\t")

--- a/backend/internal/config/project_path.go
+++ b/backend/internal/config/project_path.go
@@ -61,7 +61,10 @@ func checkProjectPath(givenProjectPath string) (string, error) {
 	}
 
 	return "", ProjectPathNotFoundError{visited: []string{givenProjectPath}}
+}
 
+func GetProjectPath() (string, error) {
+	return projectPathState.GetValue()
 }
 
 var projectPathState = static.CreateOnce(func() (string, error) {
@@ -85,10 +88,6 @@ var projectPathState = static.CreateOnce(func() (string, error) {
 	}
 	return checkProjectPath(discoveredProjectPath)
 })
-
-func GetProjectPath() (string, error) {
-	return projectPathState.GetValue()
-}
 
 func SetProjectPath(givenProjectPath string) (string, error) {
 	didSet, value, err := projectPathState.Init(func() (string, error) {

--- a/backend/internal/config/project_path.go
+++ b/backend/internal/config/project_path.go
@@ -45,10 +45,6 @@ func findProjectPath(currentDir string, visited []string) (string, error) {
 	return currentDir, nil
 }
 
-func GetProjectPath() (string, error) {
-	return projectPathState.GetValue()
-}
-
 func checkProjectPath(givenProjectPath string) (string, error) {
 	if !filepath.IsAbs(givenProjectPath) {
 		cwd, err := os.Getwd()
@@ -66,18 +62,6 @@ func checkProjectPath(givenProjectPath string) (string, error) {
 
 	return "", ProjectPathNotFoundError{visited: []string{givenProjectPath}}
 
-}
-
-func SetProjectPath(givenProjectPath string) (string, error) {
-	didSet, value, err := projectPathState.Init(func() (string, error) {
-		return checkProjectPath(givenProjectPath)
-	})
-
-	if !didSet {
-		return "", fmt.Errorf("error: failed to set project path: %s", err)
-	}
-
-	return value, err
 }
 
 var projectPathState = static.CreateOnce(func() (string, error) {
@@ -101,6 +85,22 @@ var projectPathState = static.CreateOnce(func() (string, error) {
 	}
 	return checkProjectPath(discoveredProjectPath)
 })
+
+func GetProjectPath() (string, error) {
+	return projectPathState.GetValue()
+}
+
+func SetProjectPath(givenProjectPath string) (string, error) {
+	didSet, value, err := projectPathState.Init(func() (string, error) {
+		return checkProjectPath(givenProjectPath)
+	})
+
+	if !didSet {
+		return "", fmt.Errorf("error: failed to set project path: %s", err)
+	}
+
+	return value, err
+}
 
 func GetProjectPathOrExit() string {
 	projectPath, err := GetProjectPath()

--- a/backend/internal/config/project_path.go
+++ b/backend/internal/config/project_path.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"robinplatform.dev/internal/static"
 )
 
 var (
@@ -66,7 +68,7 @@ func SetProjectPath(givenProjectPath string) (string, error) {
 	return "", ProjectPathNotFoundError{visited: []string{givenProjectPath}}
 }
 
-func GetProjectPath() (string, error) {
+var GetProjectPath = static.CreateOnce(func() (string, error) {
 	if projectPath == "" {
 		// First try to load it from the env. We don't use this as a hint, but rather as an
 		// exact path to the project. We just perform a quick check to make sure it is a valid
@@ -89,7 +91,7 @@ func GetProjectPath() (string, error) {
 		return SetProjectPath(discoveredProjectPath)
 	}
 	return projectPath, nil
-}
+})
 
 func GetProjectPathOrExit() string {
 	projectPath, err := GetProjectPath()

--- a/backend/internal/config/project_path.go
+++ b/backend/internal/config/project_path.go
@@ -9,10 +9,6 @@ import (
 	"robinplatform.dev/internal/static"
 )
 
-var (
-	projectPath string
-)
-
 func fileExists(filename string) bool {
 	info, err := os.Stat(filename)
 	if os.IsNotExist(err) {
@@ -49,7 +45,11 @@ func findProjectPath(currentDir string, visited []string) (string, error) {
 	return currentDir, nil
 }
 
-func SetProjectPath(givenProjectPath string) (string, error) {
+func GetProjectPath() (string, error) {
+	return projectPathState.GetValue()
+}
+
+func checkProjectPath(givenProjectPath string) (string, error) {
 	if !filepath.IsAbs(givenProjectPath) {
 		cwd, err := os.Getwd()
 		if err != nil {
@@ -61,36 +61,45 @@ func SetProjectPath(givenProjectPath string) (string, error) {
 
 	givenProjectPath = filepath.Clean(givenProjectPath)
 	if fileExists(filepath.Join(givenProjectPath, "robin.json")) {
-		projectPath = givenProjectPath
-		return projectPath, nil
+		return givenProjectPath, nil
 	}
 
 	return "", ProjectPathNotFoundError{visited: []string{givenProjectPath}}
+
 }
 
-var GetProjectPath = static.CreateOnce(func() (string, error) {
-	if projectPath == "" {
-		// First try to load it from the env. We don't use this as a hint, but rather as an
-		// exact path to the project. We just perform a quick check to make sure it is a valid
-		// robin project.
-		envProjectPath := os.Getenv("ROBIN_PROJECT_PATH")
-		if envProjectPath != "" {
-			return SetProjectPath(envProjectPath)
-		}
+func SetProjectPath(givenProjectPath string) (string, error) {
+	didSet, value, err := projectPathState.Init(func() (string, error) {
+		return checkProjectPath(givenProjectPath)
+	})
 
-		// Otherwise perform a recursive check from the cwd to find the closest robin project.
-		cwd, err := os.Getwd()
-		if err != nil {
-			panic(fmt.Errorf("failed to get cwd: %s", err))
-		}
-
-		discoveredProjectPath, err := findProjectPath(cwd, nil)
-		if err != nil {
-			return "", err
-		}
-		return SetProjectPath(discoveredProjectPath)
+	if !didSet {
+		return "", fmt.Errorf("error: failed to set project path: %s", err)
 	}
-	return projectPath, nil
+
+	return value, err
+}
+
+var projectPathState = static.CreateOnce(func() (string, error) {
+	// First try to load it from the env. We don't use this as a hint, but rather as an
+	// exact path to the project. We just perform a quick check to make sure it is a valid
+	// robin project.
+	envProjectPath := os.Getenv("ROBIN_PROJECT_PATH")
+	if envProjectPath != "" {
+		return checkProjectPath(envProjectPath)
+	}
+
+	// Otherwise perform a recursive check from the cwd to find the closest robin project.
+	cwd, err := os.Getwd()
+	if err != nil {
+		panic(fmt.Errorf("failed to get cwd: %s", err))
+	}
+
+	discoveredProjectPath, err := findProjectPath(cwd, nil)
+	if err != nil {
+		return "", err
+	}
+	return checkProjectPath(discoveredProjectPath)
 })
 
 func GetProjectPathOrExit() string {

--- a/backend/internal/config/project_path.go
+++ b/backend/internal/config/project_path.go
@@ -63,10 +63,6 @@ func checkProjectPath(givenProjectPath string) (string, error) {
 	return "", ProjectPathNotFoundError{visited: []string{givenProjectPath}}
 }
 
-func GetProjectPath() (string, error) {
-	return projectPathState.GetValue()
-}
-
 var projectPathState = static.CreateOnce(func() (string, error) {
 	// First try to load it from the env. We don't use this as a hint, but rather as an
 	// exact path to the project. We just perform a quick check to make sure it is a valid
@@ -99,6 +95,10 @@ func SetProjectPath(givenProjectPath string) (string, error) {
 	}
 
 	return value, err
+}
+
+func GetProjectPath() (string, error) {
+	return projectPathState.GetValue()
 }
 
 func GetProjectPathOrExit() string {

--- a/backend/internal/static/once.go
+++ b/backend/internal/static/once.go
@@ -1,0 +1,16 @@
+package static
+
+import "sync"
+
+func CreateOnce[T any](creator func() T) func() T {
+	var value T
+	var once sync.Once
+
+	return func() T {
+		once.Do(func() {
+			value = creator()
+		})
+
+		return value
+	}
+}

--- a/backend/internal/static/once.go
+++ b/backend/internal/static/once.go
@@ -1,23 +1,21 @@
 package static
 
-import (
-	"sync"
-)
+import "sync"
 
 type OnceInit[T any] struct {
 	value T
 	err   error
+	once  sync.Once
 
 	Init     func(func() (T, error)) (bool, T, error)
 	GetValue func() (T, error)
 }
 
-func CreateOnce[T any](creator func() (T, error)) OnceInit[T] {
-	var once sync.Once
-	var out OnceInit[T]
+func CreateOnce[T any](creator func() (T, error)) *OnceInit[T] {
+	out := &OnceInit[T]{}
 
 	out.GetValue = func() (T, error) {
-		once.Do(func() {
+		out.once.Do(func() {
 			out.value, out.err = creator()
 		})
 
@@ -26,7 +24,7 @@ func CreateOnce[T any](creator func() (T, error)) OnceInit[T] {
 
 	out.Init = func(creator func() (T, error)) (bool, T, error) {
 		didInit := false
-		once.Do(func() {
+		out.once.Do(func() {
 			out.value, out.err = creator()
 			didInit = true
 		})

--- a/backend/internal/static/once.go
+++ b/backend/internal/static/once.go
@@ -2,15 +2,16 @@ package static
 
 import "sync"
 
-func CreateOnce[T any](creator func() T) func() T {
+func CreateOnce[T any](creator func() (T, error)) func() (T, error) {
 	var value T
+	var err error
 	var once sync.Once
 
-	return func() T {
+	return func() (T, error) {
 		once.Do(func() {
-			value = creator()
+			value, err = creator()
 		})
 
-		return value
+		return value, err
 	}
 }

--- a/backend/internal/static/once.go
+++ b/backend/internal/static/once.go
@@ -7,17 +7,17 @@ import (
 type OnceInit[T any] struct {
 	value T
 	err   error
-	once  sync.Once
 
 	Init     func(func() (T, error)) (bool, T, error)
 	GetValue func() (T, error)
 }
 
 func CreateOnce[T any](creator func() (T, error)) OnceInit[T] {
+	var once sync.Once
 	var out OnceInit[T]
 
 	out.GetValue = func() (T, error) {
-		out.once.Do(func() {
+		once.Do(func() {
 			out.value, out.err = creator()
 		})
 
@@ -26,7 +26,7 @@ func CreateOnce[T any](creator func() (T, error)) OnceInit[T] {
 
 	out.Init = func(creator func() (T, error)) (bool, T, error) {
 		didInit := false
-		out.once.Do(func() {
+		once.Do(func() {
 			out.value, out.err = creator()
 			didInit = true
 		})

--- a/backend/internal/static/once_test.go
+++ b/backend/internal/static/once_test.go
@@ -21,7 +21,7 @@ func TestOnce(t *testing.T) {
 	})
 
 	if didInit {
-		t.Errorf("Shoul not have initialized twice")
+		t.Errorf("Should not have initialized twice")
 	}
 	if err != nil {
 		t.Error(err)

--- a/backend/internal/static/once_test.go
+++ b/backend/internal/static/once_test.go
@@ -1,0 +1,33 @@
+package static
+
+import "testing"
+
+func TestOnce(t *testing.T) {
+	once := CreateOnce(func() (int, error) {
+		return 1, nil
+	})
+
+	value, err := once.GetValue()
+
+	if err != nil {
+		t.Error(err)
+	}
+	if value != 1 {
+		t.Errorf("Expected 1, got %d", value)
+	}
+
+	didInit, value, err := once.Init(func() (int, error) {
+		return 2, nil
+	})
+
+	if didInit {
+		t.Errorf("Shoul not have initialized twice")
+	}
+	if err != nil {
+		t.Error(err)
+	}
+	if value != 1 {
+		t.Errorf("Expected 2, got %d", value)
+	}
+
+}


### PR DESCRIPTION
- Add `CreateOnce` utility
- Use `CreateOnce` in `config` to synchronize initialization of the project path
- Make project config not depend on global state
- Add a test for loading the project config