### PR TITLE
Change `<title>` contents so they don't trigger warning

### DIFF
--- a/frontend/pages/app/[id]/[[...appRoute]].tsx
+++ b/frontend/pages/app/[id]/[[...appRoute]].tsx
@@ -12,7 +12,7 @@ export default function Page() {
 	return (
 		<div className={'full col'}>
 			<Head>
-				<title>{title || 'Error'} | Robin</title>
+				<title>{`${title || 'Error'} | Robin`}</title>
 			</Head>
 
 			{id && <AppWindow id={String(id)} setTitle={setTitle} />}


### PR DESCRIPTION
Next.js warns when there's multiple children on a `<title>` tag, so this PR changes it to not have multiple.