### PR TITLE
Make daemon keepAlive more active in Development mode

### DIFF
--- a/backend/internal/compile/daemon.go
+++ b/backend/internal/compile/daemon.go
@@ -152,7 +152,13 @@ func (app *CompiledApp) keepAlive() {
 			}
 		}
 
-		time.Sleep(10 * time.Second)
+		// TODO: This should be less frequent. I've set it to be higher right now
+		// to make development of robin apps easier/faster, but it should be lower.
+		if config.GetReleaseChannel() == "dev" {
+			time.Sleep(time.Second / 4)
+		} else {
+			time.Sleep(10 * time.Second)
+		}
 	}
 }
 


### PR DESCRIPTION
This reduces the delay for the compile-edit-debug cycle for development of the server manager package. I've added #72 to track the actual fix to make the experience better, but for now this is useful.