### PR TITLE
[WIP] Refactor Process Manager

### DIFF
--- a/backend/internal/compile/daemon.go
+++ b/backend/internal/compile/daemon.go
@@ -92,7 +92,7 @@ func (app *CompiledApp) getProcessId() process.ProcessId {
 
 	return process.ProcessId{
 		Kind:   process.KindAppDaemon,
-		Source: fmt.Sprintf("%s-app-daemon", projectAlias),
+		Source: projectAlias,
 		Key:    app.Id,
 	}
 }

--- a/backend/internal/compile/daemon.go
+++ b/backend/internal/compile/daemon.go
@@ -159,7 +159,7 @@ func (app *CompiledApp) GetAppDir() (string, error) {
 	return filepath.Join(config.GetRobinPath(), "projects", projectAlias, "apps", app.Id), nil
 }
 
-func (app *CompiledApp) setupJsDaemon(processConfig *process.ProcessConfig[process.DummyMeta]) error {
+func (app *CompiledApp) setupJsDaemon(processConfig *process.ProcessConfig) error {
 	appDir, err := app.GetAppDir()
 	if err != nil {
 		return fmt.Errorf("failed to start app server: %w", err)
@@ -227,7 +227,7 @@ func (app *CompiledApp) setupJsDaemon(processConfig *process.ProcessConfig[proce
 	return nil
 }
 
-func (app *CompiledApp) setupCustomDaemon(appConfig project.RobinAppConfig, processConfig *process.ProcessConfig[process.DummyMeta]) error {
+func (app *CompiledApp) setupCustomDaemon(appConfig project.RobinAppConfig, processConfig *process.ProcessConfig) error {
 	processConfig.Command = appConfig.Daemon[0]
 	processConfig.Args = appConfig.Daemon[1:]
 
@@ -281,7 +281,7 @@ func (app *CompiledApp) StartServer() error {
 	}
 
 	projectPath := project.GetProjectPathOrExit()
-	processConfig := process.ProcessConfig[process.DummyMeta]{
+	processConfig := process.ProcessConfig{
 		Id:      app.getProcessId(),
 		WorkDir: appDir,
 		Env: map[string]string{
@@ -289,7 +289,6 @@ func (app *CompiledApp) StartServer() error {
 			"ROBIN_PROCESS_TYPE": "daemon",
 			"ROBIN_PROJECT_PATH": projectPath,
 		},
-		Meta: process.DummyMeta{},
 	}
 
 	// Setup the daemon runner

--- a/backend/internal/compile/daemon.go
+++ b/backend/internal/compile/daemon.go
@@ -26,31 +26,11 @@ import (
 	es "github.com/evanw/esbuild/pkg/api"
 )
 
-type processMeta struct {
-	Port int `json:"port"`
-}
-
 var (
-	processManager *process.ProcessManager[processMeta]
-
 	// TODO: add something like a write handle to processManager so we don't
 	// need to use our own mutex
 	daemonProcessMux = &sync.Mutex{}
 )
-
-func init() {
-	robinPath := config.GetRobinPath()
-
-	var err error
-	processManager, err = process.NewProcessManager[processMeta](filepath.Join(
-		robinPath,
-		"data",
-		"app-processes.db",
-	))
-	if err != nil {
-		panic(fmt.Errorf("failed to initialize compiler: %w", err))
-	}
-}
 
 func getExtractServerPlugins(appConfig project.RobinAppConfig, app *CompiledApp) []es.Plugin {
 	return []es.Plugin{
@@ -118,7 +98,7 @@ func (app *CompiledApp) getProcessId() process.ProcessId {
 }
 
 func (app *CompiledApp) IsAlive() bool {
-	process, err := processManager.FindById(app.getProcessId())
+	process, err := process.Manager.FindById(app.getProcessId())
 	if err != nil {
 		return false
 	}
@@ -128,7 +108,7 @@ func (app *CompiledApp) IsAlive() bool {
 	}
 
 	// Send a ping to the process
-	resp, err := http.Get(fmt.Sprintf("http://localhost:%d/api/health", process.Meta.Port))
+	resp, err := http.Get(fmt.Sprintf("http://localhost:%d/api/health", process.Port))
 	if resp != nil {
 		resp.Body.Close()
 	}
@@ -179,7 +159,7 @@ func (app *CompiledApp) GetAppDir() (string, error) {
 	return filepath.Join(config.GetRobinPath(), "projects", projectAlias, "apps", app.Id), nil
 }
 
-func (app *CompiledApp) setupJsDaemon(processConfig *process.ProcessConfig[processMeta]) error {
+func (app *CompiledApp) setupJsDaemon(processConfig *process.ProcessConfig[process.DummyMeta]) error {
 	appDir, err := app.GetAppDir()
 	if err != nil {
 		return fmt.Errorf("failed to start app server: %w", err)
@@ -247,7 +227,7 @@ func (app *CompiledApp) setupJsDaemon(processConfig *process.ProcessConfig[proce
 	return nil
 }
 
-func (app *CompiledApp) setupCustomDaemon(appConfig project.RobinAppConfig, processConfig *process.ProcessConfig[processMeta]) error {
+func (app *CompiledApp) setupCustomDaemon(appConfig project.RobinAppConfig, processConfig *process.ProcessConfig[process.DummyMeta]) error {
 	processConfig.Command = appConfig.Daemon[0]
 	processConfig.Args = appConfig.Daemon[1:]
 
@@ -301,7 +281,7 @@ func (app *CompiledApp) StartServer() error {
 	}
 
 	projectPath := project.GetProjectPathOrExit()
-	processConfig := process.ProcessConfig[processMeta]{
+	processConfig := process.ProcessConfig[process.DummyMeta]{
 		Id:      app.getProcessId(),
 		WorkDir: appDir,
 		Env: map[string]string{
@@ -309,7 +289,7 @@ func (app *CompiledApp) StartServer() error {
 			"ROBIN_PROCESS_TYPE": "daemon",
 			"ROBIN_PROJECT_PATH": projectPath,
 		},
-		Meta: processMeta{},
+		Meta: process.DummyMeta{},
 	}
 
 	// Setup the daemon runner
@@ -334,10 +314,10 @@ func (app *CompiledApp) StartServer() error {
 
 	// Add port info to the process config
 	processConfig.Env["PORT"] = strPortAvailable
-	processConfig.Meta.Port = portAvailable
+	processConfig.Port = portAvailable
 
 	// Start the app server process
-	serverProcess, err := processManager.SpawnPath(processConfig)
+	serverProcess, err := process.Manager.SpawnPath(processConfig)
 	if err != nil && !errors.Is(err, process.ErrProcessAlreadyExists) {
 		logger.Err("Failed to start app server", log.Ctx{
 			"appId": app.Id,
@@ -354,7 +334,7 @@ func (app *CompiledApp) StartServer() error {
 		}
 
 		// Send a ping to the process
-		resp, err := http.Get(fmt.Sprintf("http://localhost:%d/api/health", serverProcess.Meta.Port))
+		resp, err := http.Get(fmt.Sprintf("http://localhost:%d/api/health", serverProcess.Port))
 		if err == nil && resp.StatusCode == http.StatusOK {
 			if atomic.CompareAndSwapInt64(app.keepAliveRunning, 0, 1) {
 				go app.keepAlive()
@@ -396,7 +376,7 @@ func (app *CompiledApp) StopServer() error {
 	daemonProcessMux.Lock()
 	defer daemonProcessMux.Unlock()
 
-	if err := processManager.Kill(app.getProcessId()); err != nil && !errors.Is(err, process.ErrProcessNotFound) {
+	if err := process.Manager.Kill(app.getProcessId()); err != nil && !errors.Is(err, process.ErrProcessNotFound) {
 		return fmt.Errorf("failed to stop app server: %w", err)
 	}
 	return nil
@@ -413,7 +393,7 @@ func (app *CompiledApp) Request(ctx context.Context, method string, reqPath stri
 		app.httpClient = &http.Client{}
 	}
 
-	serverProcess, err := processManager.FindById(app.getProcessId())
+	serverProcess, err := process.Manager.FindById(app.getProcessId())
 	if err != nil {
 		return AppResponse{StatusCode: 500, Err: fmt.Sprintf("failed to make app request: %s", err)}
 	}
@@ -432,7 +412,7 @@ func (app *CompiledApp) Request(ctx context.Context, method string, reqPath stri
 	req, err := http.NewRequestWithContext(
 		ctx,
 		method,
-		fmt.Sprintf("http://localhost:%d%s", serverProcess.Meta.Port, reqPath),
+		fmt.Sprintf("http://localhost:%d%s", serverProcess.Port, reqPath),
 		bytes.NewReader(serializedBody),
 	)
 	req.Header.Set("Content-Type", "application/json")

--- a/backend/internal/compile/daemon.go
+++ b/backend/internal/compile/daemon.go
@@ -91,9 +91,9 @@ func (app *CompiledApp) getProcessId() process.ProcessId {
 	}
 
 	return process.ProcessId{
-		Namespace:    process.NamespaceExtensionDaemon,
-		NamespaceKey: fmt.Sprintf("%s-app-daemon", projectAlias),
-		Key:          app.Id,
+		Kind:   process.KindAppDaemon,
+		Source: fmt.Sprintf("%s-app-daemon", projectAlias),
+		Key:    app.Id,
 	}
 }
 

--- a/backend/internal/model/store.go
+++ b/backend/internal/model/store.go
@@ -122,6 +122,20 @@ func (store *Store[Model]) Find(matcher func(row Model) bool) (Model, bool) {
 	return r.Find(matcher)
 }
 
+func (r *RHandle[Model]) ShallowCopyOutData() []Model {
+	out := make([]Model, 0, len(r.store.data))
+	out = append(out, r.store.data...)
+
+	return out
+}
+
+func (store *Store[Model]) ShallowCopyOutData() []Model {
+	r := store.ReadHandle()
+	defer r.Close()
+
+	return r.ShallowCopyOutData()
+}
+
 func (store *Store[_]) flush() error {
 	buf, err := json.Marshal(store.data)
 	if err != nil {

--- a/backend/internal/model/store.go
+++ b/backend/internal/model/store.go
@@ -66,6 +66,13 @@ func (store *Store[Model]) ReadHandle() RHandle[Model] {
 	return RHandle[Model]{store}
 }
 
+// Creates a read handle. Closing this will cause a failure in the underlying RWLock,
+// because it's currently locked for writing, but read handles only close for
+// reading.
+func (w *WHandle[Model]) UncloseableReadHandle() RHandle[Model] {
+	return RHandle[Model]{store: w.store}
+}
+
 func (w *WHandle[Model]) Close() {
 	w.store.rwMux.Unlock()
 }

--- a/backend/internal/process/handle.go
+++ b/backend/internal/process/handle.go
@@ -1,0 +1,29 @@
+package process
+
+import "robinplatform.dev/internal/model"
+
+type RHandle struct {
+	db model.RHandle[Process]
+}
+
+func (manager *ProcessManager) ReadHandle() RHandle {
+	return RHandle{db: manager.db.ReadHandle()}
+}
+
+func (r *RHandle) Close() {
+	r.db.Close()
+}
+
+func (manager *ProcessManager) FindById(id ProcessId) (*Process, error) {
+	r := manager.ReadHandle()
+	defer r.Close()
+
+	return r.FindById(id)
+}
+
+func (manager *ProcessManager) IsAlive(id ProcessId) bool {
+	r := manager.ReadHandle()
+	defer r.Close()
+
+	return r.IsAlive(id)
+}

--- a/backend/internal/process/handle.go
+++ b/backend/internal/process/handle.go
@@ -6,24 +6,74 @@ type RHandle struct {
 	db model.RHandle[Process]
 }
 
+type WHandle struct {
+	db model.WHandle[Process]
+}
+
 func (manager *ProcessManager) ReadHandle() RHandle {
 	return RHandle{db: manager.db.ReadHandle()}
+}
+
+func (manager *ProcessManager) WriteHandle() WHandle {
+	return WHandle{db: manager.db.WriteHandle()}
+}
+
+func (w *WHandle) Close() {
+	w.db.Close()
 }
 
 func (r *RHandle) Close() {
 	r.db.Close()
 }
 
-func (manager *ProcessManager) FindById(id ProcessId) (*Process, error) {
-	r := manager.ReadHandle()
+func (m *ProcessManager) FindById(id ProcessId) (*Process, error) {
+	r := m.ReadHandle()
 	defer r.Close()
 
 	return r.FindById(id)
 }
 
-func (manager *ProcessManager) IsAlive(id ProcessId) bool {
-	r := manager.ReadHandle()
+func (w *WHandle) FindById(id ProcessId) (*Process, error) {
+	r := RHandle{db: w.db.UncloseableReadHandle()}
+	return r.FindById(id)
+}
+
+func (m *ProcessManager) IsAlive(id ProcessId) bool {
+	r := m.ReadHandle()
 	defer r.Close()
 
 	return r.IsAlive(id)
+}
+
+func (w *WHandle) IsAlive(id ProcessId) bool {
+	r := RHandle{db: w.db.UncloseableReadHandle()}
+	return r.IsAlive(id)
+}
+
+func (m *ProcessManager) Remove(id ProcessId) error {
+	w := m.WriteHandle()
+	defer w.Close()
+
+	return w.Remove(id)
+}
+
+func (m *ProcessManager) Kill(id ProcessId) error {
+	w := m.WriteHandle()
+	defer w.Close()
+
+	return w.Kill(id)
+}
+
+func (m *ProcessManager) SpawnPath(config ProcessConfig) (*Process, error) {
+	w := m.WriteHandle()
+	defer w.Close()
+
+	return w.SpawnPath(config)
+}
+
+func (m *ProcessManager) Spawn(config ProcessConfig) (*Process, error) {
+	w := m.WriteHandle()
+	defer w.Close()
+
+	return w.Spawn(config)
 }

--- a/backend/internal/process/handle.go
+++ b/backend/internal/process/handle.go
@@ -50,6 +50,18 @@ func (w *WHandle) IsAlive(id ProcessId) bool {
 	return r.IsAlive(id)
 }
 
+func (m *ProcessManager) CopyOutData() []Process {
+	r := m.ReadHandle()
+	defer r.Close()
+
+	return r.CopyOutData()
+}
+
+func (w *WHandle) CopyOutData() []Process {
+	r := RHandle{db: w.db.UncloseableReadHandle()}
+	return r.CopyOutData()
+}
+
 func (m *ProcessManager) Remove(id ProcessId) error {
 	w := m.WriteHandle()
 	defer w.Close()

--- a/backend/internal/process/manager.go
+++ b/backend/internal/process/manager.go
@@ -6,9 +6,6 @@ import (
 	"robinplatform.dev/internal/config"
 )
 
-type DummyMeta struct {
-}
-
 var Manager *ProcessManager
 
 func init() {

--- a/backend/internal/process/manager.go
+++ b/backend/internal/process/manager.go
@@ -9,11 +9,11 @@ import (
 type DummyMeta struct {
 }
 
-var Manager *ProcessManager[DummyMeta]
+var Manager *ProcessManager
 
 func init() {
 	robinPath := config.GetRobinPath()
-	manager, err := NewProcessManager[DummyMeta](filepath.Join(
+	manager, err := NewProcessManager(filepath.Join(
 		robinPath,
 		"data",
 		"spawned-processes.db",

--- a/backend/internal/process/manager.go
+++ b/backend/internal/process/manager.go
@@ -1,0 +1,27 @@
+package process
+
+import (
+	"path/filepath"
+
+	"robinplatform.dev/internal/config"
+)
+
+type DummyMeta struct {
+}
+
+var Manager *ProcessManager[DummyMeta]
+
+func init() {
+	robinPath := config.GetRobinPath()
+	manager, err := NewProcessManager[DummyMeta](filepath.Join(
+		robinPath,
+		"data",
+		"spawned-processes.db",
+	))
+
+	if err != nil {
+		panic(err)
+	}
+
+	Manager = manager
+}

--- a/backend/internal/process/process.go
+++ b/backend/internal/process/process.go
@@ -29,11 +29,11 @@ const (
 // An identifier for a process.
 type ProcessId struct {
 	// The kind of process this is.
-	Kind ProcessKind
+	Kind ProcessKind `json:"kind"`
 	// The name of the system/app that spawned this process
-	Source string
+	Source string `json:"source"`
 	// The name that this process has been given
-	Key string
+	Key string `json:"key"`
 }
 
 func (id ProcessId) String() string {
@@ -65,14 +65,14 @@ func (processConfig *ProcessConfig) getLogFilePath() string {
 }
 
 type Process struct {
-	Id        ProcessId
-	Pid       int
-	StartedAt time.Time
-	WorkDir   string
-	Env       map[string]string
-	Command   string
-	Args      []string
-	Port      int // see above
+	Id        ProcessId         `json:"id"`
+	Pid       int               `json:"pid"`
+	StartedAt time.Time         `json:"startedAt"`
+	WorkDir   string            `json:"workDir"`
+	Env       map[string]string `json:"env"`
+	Command   string            `json:"command"`
+	Args      []string          `json:"args"`
+	Port      int               `json:"port"` // see docs in ProcessConfig
 }
 
 // TODO: Avoid logging entire Env
@@ -338,4 +338,24 @@ func (w *WHandle) Remove(id ProcessId) error {
 	}
 
 	return nil
+}
+
+func (r *RHandle) CopyOutData() []Process {
+	data := r.db.ShallowCopyOutData()
+
+	for i := 0; i < len(data); i += 1 {
+		proc := &data[i]
+
+		env := proc.Env
+		proc.Env = make(map[string]string, len(env))
+		for k, v := range env {
+			proc.Env[k] = v
+		}
+
+		args := proc.Args
+		proc.Args = make([]string, 0, len(args))
+		proc.Args = append(proc.Args, args...)
+	}
+
+	return data
 }

--- a/backend/internal/process/process.go
+++ b/backend/internal/process/process.go
@@ -50,7 +50,12 @@ type ProcessConfig[Meta any] struct {
 	Env     map[string]string
 	Command string
 	Args    []string
-	Meta    Meta
+
+	// Ideally the port should be optional, and be somewhat integrated into
+	// whatever the healthcheck code ends up being, but for now this works decently well.
+	Port int
+
+	Meta Meta
 }
 
 func (processConfig *ProcessConfig[_]) getLogFilePath() string {
@@ -68,6 +73,7 @@ type Process[Meta any] struct {
 	Env       map[string]string
 	Command   string
 	Args      []string
+	Port      int // see above
 	Meta      Meta
 }
 

--- a/backend/internal/process/process.go
+++ b/backend/internal/process/process.go
@@ -184,19 +184,16 @@ func NewProcessManager(dbPath string) (*ProcessManager, error) {
 	return manager, nil
 }
 
-func (manager *ProcessManager) FindById(id ProcessId) (*Process, error) {
-	r := manager.db.ReadHandle()
-	defer r.Close()
-
-	procEntry, found := r.Find(findById(id))
+func (r *RHandle) FindById(id ProcessId) (*Process, error) {
+	procEntry, found := r.db.Find(findById(id))
 	if !found {
 		return nil, processNotFound(id)
 	}
 	return &procEntry, nil
 }
 
-func (m *ProcessManager) IsAlive(id ProcessId) bool {
-	process, err := m.FindById(id)
+func (r *RHandle) IsAlive(id ProcessId) bool {
+	process, err := r.FindById(id)
 	if err != nil {
 		return false
 	}

--- a/backend/internal/process/process.go
+++ b/backend/internal/process/process.go
@@ -283,6 +283,7 @@ func (w *WHandle) Spawn(procConfig ProcessConfig) (*Process, error) {
 		Args:      procConfig.Args,
 		Pid:       proc.Pid,
 		Env:       procConfig.Env,
+		Port:      procConfig.Port,
 	}
 
 	// Reap zombies

--- a/backend/internal/process/process.go
+++ b/backend/internal/process/process.go
@@ -340,6 +340,11 @@ func (w *WHandle) Remove(id ProcessId) error {
 	return nil
 }
 
+// TODO:
+//   - Maybe this should take in a function and allow the user
+//     to change the data before its outputted
+//   - Also, since there's no GC right now, old processes
+//     that are dead will still have their entries in the DB
 func (r *RHandle) CopyOutData() []Process {
 	data := r.db.ShallowCopyOutData()
 

--- a/backend/internal/process/process_posix.go
+++ b/backend/internal/process/process_posix.go
@@ -15,11 +15,11 @@ func getProcessSysAttrs() *syscall.SysProcAttr {
 
 // Kill will kill the process with the given id (not PID), and remove it from
 // the internal database.
-func (m *ProcessManager[Meta]) Kill(id ProcessId) error {
+func (m *ProcessManager) Kill(id ProcessId) error {
 	w := m.db.WriteHandle()
 	defer w.Close()
 
-	procEntry, found := w.Find(findById[Meta](id))
+	procEntry, found := w.Find(findById(id))
 	if !found {
 		return processNotFound(id)
 	}
@@ -29,7 +29,7 @@ func (m *ProcessManager[Meta]) Kill(id ProcessId) error {
 		return fmt.Errorf("failed to kill process: %w", err)
 	}
 
-	if err := w.Delete(findById[Meta](id)); err != nil {
+	if err := w.Delete(findById(id)); err != nil {
 		return err
 	}
 

--- a/backend/internal/process/process_posix.go
+++ b/backend/internal/process/process_posix.go
@@ -15,11 +15,8 @@ func getProcessSysAttrs() *syscall.SysProcAttr {
 
 // Kill will kill the process with the given id (not PID), and remove it from
 // the internal database.
-func (m *ProcessManager) Kill(id ProcessId) error {
-	w := m.db.WriteHandle()
-	defer w.Close()
-
-	procEntry, found := w.Find(findById(id))
+func (w *WHandle) Kill(id ProcessId) error {
+	procEntry, found := w.db.Find(findById(id))
 	if !found {
 		return processNotFound(id)
 	}
@@ -29,7 +26,7 @@ func (m *ProcessManager) Kill(id ProcessId) error {
 		return fmt.Errorf("failed to kill process: %w", err)
 	}
 
-	if err := w.Delete(findById(id)); err != nil {
+	if err := w.db.Delete(findById(id)); err != nil {
 		return err
 	}
 

--- a/backend/internal/process/process_test.go
+++ b/backend/internal/process/process_test.go
@@ -10,7 +10,7 @@ func TestSpawnProcess(t *testing.T) {
 	dir := t.TempDir()
 	dbFile := filepath.Join(dir, "testing.db")
 
-	manager, err := NewProcessManager[struct{}](dbFile)
+	manager, err := NewProcessManager(dbFile)
 	if err != nil {
 		t.Fatalf("error loading DB: %s", err.Error())
 	}
@@ -21,7 +21,7 @@ func TestSpawnProcess(t *testing.T) {
 		Key:          "long",
 	}
 
-	_, err = manager.SpawnPath(ProcessConfig[struct{}]{
+	_, err = manager.SpawnPath(ProcessConfig{
 		Id:      id,
 		Command: "sleep",
 		Args:    []string{"100"},
@@ -44,7 +44,7 @@ func TestSpawnDead(t *testing.T) {
 	dir := t.TempDir()
 	dbFile := filepath.Join(dir, "testing.db")
 
-	manager, err := NewProcessManager[struct{}](dbFile)
+	manager, err := NewProcessManager(dbFile)
 	if err != nil {
 		t.Fatalf("error loading DB: %s", err.Error())
 	}
@@ -55,7 +55,7 @@ func TestSpawnDead(t *testing.T) {
 		Key:          "short",
 	}
 
-	_, err = manager.SpawnPath(ProcessConfig[struct{}]{
+	_, err = manager.SpawnPath(ProcessConfig{
 		Id:      id,
 		Command: "sleep",
 		Args:    []string{"0"},

--- a/backend/internal/process/process_test.go
+++ b/backend/internal/process/process_test.go
@@ -16,9 +16,9 @@ func TestSpawnProcess(t *testing.T) {
 	}
 
 	id := ProcessId{
-		Namespace:    NamespaceInternal,
-		NamespaceKey: "default",
-		Key:          "long",
+		Kind:   KindInternal,
+		Source: "default",
+		Key:    "long",
 	}
 
 	_, err = manager.SpawnPath(ProcessConfig{
@@ -50,9 +50,9 @@ func TestSpawnDead(t *testing.T) {
 	}
 
 	id := ProcessId{
-		Namespace:    NamespaceInternal,
-		NamespaceKey: "default",
-		Key:          "short",
+		Kind:   KindInternal,
+		Source: "default",
+		Key:    "short",
 	}
 
 	_, err = manager.SpawnPath(ProcessConfig{

--- a/backend/internal/process/process_windows.go
+++ b/backend/internal/process/process_windows.go
@@ -17,11 +17,8 @@ func getProcessSysAttrs() *syscall.SysProcAttr {
 // Kill will kill the process with the given id (not PID), and remove it from
 // the internal database.
 // TODO: Make this work on windows
-func (m *ProcessManager) Kill(id ProcessId) error {
-	w := m.db.WriteHandle()
-	defer w.Close()
-
-	procEntry, found := w.Find(findById(id))
+func (w *WHandle) Kill(id ProcessId) error {
+	procEntry, found := w.db.Find(findById(id))
 	if !found {
 		return processNotFound(id)
 	}
@@ -40,7 +37,7 @@ func (m *ProcessManager) Kill(id ProcessId) error {
 		}
 	}
 
-	if err := w.Delete(findById(id)); err != nil {
+	if err := w.db.Delete(findById(id)); err != nil {
 		return err
 	}
 

--- a/backend/internal/process/process_windows.go
+++ b/backend/internal/process/process_windows.go
@@ -17,11 +17,11 @@ func getProcessSysAttrs() *syscall.SysProcAttr {
 // Kill will kill the process with the given id (not PID), and remove it from
 // the internal database.
 // TODO: Make this work on windows
-func (m *ProcessManager[Meta]) Kill(id ProcessId) error {
+func (m *ProcessManager) Kill(id ProcessId) error {
 	w := m.db.WriteHandle()
 	defer w.Close()
 
-	procEntry, found := w.Find(findById[Meta](id))
+	procEntry, found := w.Find(findById(id))
 	if !found {
 		return processNotFound(id)
 	}
@@ -40,7 +40,7 @@ func (m *ProcessManager[Meta]) Kill(id ProcessId) error {
 		}
 	}
 
-	if err := w.Delete(findById[Meta](id)); err != nil {
+	if err := w.Delete(findById(id)); err != nil {
 		return err
 	}
 

--- a/backend/internal/server/debug_rpc.go
+++ b/backend/internal/server/debug_rpc.go
@@ -1,0 +1,14 @@
+package server
+
+import "robinplatform.dev/internal/process"
+
+type ListProcessesInput struct {
+}
+
+var ListProcesses = InternalRpcMethod[ListProcessesInput, []process.Process]{
+	Name: "ListProcesses",
+	Run: func(c RpcRequest[ListProcessesInput]) ([]process.Process, *HttpError) {
+		data := process.Manager.CopyOutData()
+		return data, nil
+	},
+}

--- a/backend/internal/server/server.go
+++ b/backend/internal/server/server.go
@@ -66,6 +66,7 @@ func (server *Server) loadRpcMethods() {
 	GetApps.Register(server)
 	RunAppMethod.Register(server)
 	RestartApp.Register(server)
+	ListProcesses.Register(server)
 
 	// Apps RPC methods
 

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -1,14 +1,96 @@
 import Head from 'next/head';
 import React from 'react';
+import { z } from 'zod';
+import { useRpcQuery } from '../hooks/useRpcQuery';
+import toast from 'react-hot-toast';
+
+function Processes() {
+	const { data: processes, error } = useRpcQuery({
+		method: 'ListProcesses',
+		data: {},
+		result: z.array(
+			z.object({
+				id: z.object({
+					kind: z.string(),
+					source: z.string(),
+					key: z.string(),
+				}),
+				command: z.string(),
+				args: z.array(z.string()),
+			}),
+		),
+	});
+
+	React.useEffect(() => {
+		if (error) {
+			toast.error(`${String(error)}`);
+		}
+	}, [error]);
+
+	return (
+		<div
+			className={'full col robin-rounded robin-pad'}
+			style={{ backgroundColor: 'DarkSlateGray', maxHeight: '100%' }}
+		>
+			<div>Processes</div>
+
+			{/* The position relative/absolute stuff makes it so that the
+			    inner div doesn't affect layout calculations of the surrounding div.
+				I found this very confusing at first, so here's the SO post that I got it from:
+
+				https://stackoverflow.com/questions/27433183/make-scrollable-div-take-up-remaining-height
+			 */}
+			<div className={'full'} style={{ position: 'relative', flexGrow: 1 }}>
+				<div
+					className={'full col robin-gap'}
+					style={{
+						position: 'absolute',
+						top: 0,
+						left: 0,
+						right: 0,
+						bottom: 0,
+						overflowY: 'scroll',
+					}}
+				>
+					{processes?.map((value) => {
+						return (
+							<div
+								className={'robin-rounded robin-pad'}
+								style={{ backgroundColor: 'Coral' }}
+							>
+								{`${value.id.kind} ${value.id.source} ${value.id.key}`}
+
+								<pre>{JSON.stringify(value, null, 2)}</pre>
+							</div>
+						);
+					})}
+				</div>
+			</div>
+		</div>
+	);
+}
 
 export default function Home() {
 	return (
-		<div className={'robin-bg-dark-blue robin-pad full'}>
+		<div className={'robin-bg-light-blue robin-pad full'}>
 			<Head>
 				<title>Robin</title>
 			</Head>
 
-			<div className={'full col robin-rounded robin-pad'}>Hello world!</div>
+			<div
+				className={
+					'full col robin-rounded robin-pad robin-bg-dark-blue robin-gap'
+				}
+			>
+				<div>Hello world!</div>
+
+				<div
+					className={'full robin-gap'}
+					style={{ display: 'flex', maxWidth: '30rem', maxHeight: '100%' }}
+				>
+					<Processes />
+				</div>
+			</div>
 		</div>
 	);
 }

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -53,12 +53,14 @@ function Processes() {
 					}}
 				>
 					{processes?.map((value) => {
+						const key = `${value.id.kind} ${value.id.source} ${value.id.key}`;
 						return (
 							<div
+								key={key}
 								className={'robin-rounded robin-pad'}
 								style={{ backgroundColor: 'Coral' }}
 							>
-								{`${value.id.kind} ${value.id.source} ${value.id.key}`}
+								{key}
 
 								<pre>{JSON.stringify(value, null, 2)}</pre>
 							</div>


### PR DESCRIPTION
- Move process management to a single instance so that it's possible to view all running processes in a single view for debugging/dev purposes
- Switch off the generic field because it will stop making sense if all processes are in a single instance
- Add a small section to the homepage that shows all the active processes
- Fix names like "NamespaceKey" to describe what they're actually for
- Add write/read handles

TODO later:
- Delete information for dead processes