### PR TITLE
Update logging.go

### DIFF
--- a/backend/internal/log/logging.go
+++ b/backend/internal/log/logging.go
@@ -80,10 +80,9 @@ func (logger *Logger) log(level Level, msg string, ctx Ctx) {
 	}
 
 	levelStr := levelStrings[string(level)]
-	
+
 	// We always want non-debug messages to output to the log file
 	encoder.Encode(log)
-
 
 	// Debug messages are the only messages we want to filter out of the console right now.
 	// If the user wants to see them in the console, they can enable it through the proper debug namespace.

--- a/backend/internal/log/logging.go
+++ b/backend/internal/log/logging.go
@@ -1,6 +1,7 @@
 package log
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -62,9 +63,6 @@ func New(namespace string) Logger {
 }
 
 func (logger *Logger) log(level Level, msg string, ctx Ctx) {
-	if level == Debug && !debugNamespaces[logger.namespace] {
-		return
-	}
 
 	log := make(map[string]any, 4+len(ctx))
 	log["timestamp"] = time.Now().UnixMilli()
@@ -82,8 +80,21 @@ func (logger *Logger) log(level Level, msg string, ctx Ctx) {
 	}
 
 	levelStr := levelStrings[string(level)]
-	fmt.Printf("%s %s %s\n\t%s\n", levelStr, color(logger.color, logger.namespace), msg, ctxBuf)
+	
+	// We always want non-debug messages to output to the log file
 	encoder.Encode(log)
+
+
+	// Debug messages are the only messages we want to filter out of the console right now.
+	// If the user wants to see them in the console, they can enable it through the proper debug namespace.
+	if level != Debug || debugNamespaces[logger.namespace] {
+		ctxBufShortened := ctxBuf
+		if len(ctxBuf) > 300 {
+			ctxBufShortened = append([]byte{}, ctxBufShortened[:300]...)
+			ctxBufShortened = append(bytes.Trim(ctxBufShortened, " \t\n"), []byte("\n ...[truncated]")...)
+		}
+		fmt.Printf("%s %s %s\n\t%s\n", levelStr, color(logger.color, logger.namespace), msg, ctxBufShortened)
+	}
 }
 
 func (logger *Logger) Debug(msg string, ctx Ctx) {


### PR DESCRIPTION
- Always make debug messages show up in the log file
- Truncate context strings in the console that are too long
