### PR TITLE
Refactor Process IDs

### DIFF
--- a/backend/internal/compile/daemon.go
+++ b/backend/internal/compile/daemon.go
@@ -91,7 +91,6 @@ func (app *CompiledApp) getProcessId() process.ProcessId {
 	}
 
 	return process.ProcessId{
-		Kind:   process.KindAppDaemon,
 		Source: projectAlias,
 		Key:    app.Id,
 	}

--- a/backend/internal/compile/daemon.go
+++ b/backend/internal/compile/daemon.go
@@ -84,20 +84,8 @@ func getExtractServerPlugins(appConfig project.RobinAppConfig, app *CompiledApp)
 	}
 }
 
-func (app *CompiledApp) getProcessId() process.ProcessId {
-	projectAlias, err := project.GetProjectAlias()
-	if err != nil {
-		panic(fmt.Errorf("failed to get project alias: %w", err))
-	}
-
-	return process.ProcessId{
-		Source: projectAlias,
-		Key:    app.Id,
-	}
-}
-
 func (app *CompiledApp) IsAlive() bool {
-	process, err := process.Manager.FindById(app.getProcessId())
+	process, err := process.Manager.FindById(app.ProcessId)
 	if err != nil {
 		return false
 	}
@@ -281,7 +269,7 @@ func (app *CompiledApp) StartServer() error {
 
 	projectPath := project.GetProjectPathOrExit()
 	processConfig := process.ProcessConfig{
-		Id:      app.getProcessId(),
+		Id:      app.ProcessId,
 		WorkDir: appDir,
 		Env: map[string]string{
 			"ROBIN_APP_ID":       app.Id,
@@ -374,7 +362,7 @@ func (app *CompiledApp) StopServer() error {
 	daemonProcessMux.Lock()
 	defer daemonProcessMux.Unlock()
 
-	if err := process.Manager.Kill(app.getProcessId()); err != nil && !errors.Is(err, process.ErrProcessNotFound) {
+	if err := process.Manager.Kill(app.ProcessId); err != nil && !errors.Is(err, process.ErrProcessNotFound) {
 		return fmt.Errorf("failed to stop app server: %w", err)
 	}
 	return nil
@@ -391,7 +379,7 @@ func (app *CompiledApp) Request(ctx context.Context, method string, reqPath stri
 		app.httpClient = &http.Client{}
 	}
 
-	serverProcess, err := process.Manager.FindById(app.getProcessId())
+	serverProcess, err := process.Manager.FindById(app.ProcessId)
 	if err != nil {
 		return AppResponse{StatusCode: 500, Err: fmt.Sprintf("failed to make app request: %s", err)}
 	}

--- a/backend/internal/process/process.go
+++ b/backend/internal/process/process.go
@@ -24,7 +24,7 @@ type ProcessId struct {
 	// The name of the system/app that spawned this process
 	// The following names are reserved:
 	// - robin - this is for internal apps
-	// - @robinplatform/* - anything starting with @robin-platform/* is reserved for systems in Robin
+	// - @robin/* - anything starting with @robin-platform/* is reserved for systems in Robin
 	Source string `json:"source"`
 	// The name that this process has been given
 	Key string `json:"key"`
@@ -80,8 +80,8 @@ func NewId(source string, name string) (ProcessId, error) {
 		return ProcessId{}, fmt.Errorf("tried to use internal \"robin\" namespace")
 	}
 
-	if strings.HasPrefix(name, "@robinplatform/") {
-		return ProcessId{}, fmt.Errorf("tried to use internal \"@robinplatform/*\" namespace")
+	if strings.HasPrefix(name, "@robin/") {
+		return ProcessId{}, fmt.Errorf("tried to use internal \"@robin/*\" namespace")
 
 	}
 

--- a/backend/internal/process/process.go
+++ b/backend/internal/process/process.go
@@ -19,18 +19,12 @@ var (
 	logger = log.New("process")
 )
 
-type ProcessKind string
-
-const (
-	KindAppDaemon ProcessKind = "app-daemon"
-	KindInternal  ProcessKind = "internal"
-)
-
 // An identifier for a process.
 type ProcessId struct {
-	// The kind of process this is.
-	Kind ProcessKind `json:"kind"`
 	// The name of the system/app that spawned this process
+	// The following names are reserved:
+	// - robin - this is for internal apps
+	// - @robinplatform/* - anything starting with @robin-platform/* is reserved for systems in Robin
 	Source string `json:"source"`
 	// The name that this process has been given
 	Key string `json:"key"`
@@ -38,8 +32,7 @@ type ProcessId struct {
 
 func (id ProcessId) String() string {
 	return fmt.Sprintf(
-		"%s-%s-%s",
-		id.Kind,
+		"%s-%s",
 		id.Source,
 		id.Key,
 	)
@@ -60,7 +53,7 @@ type ProcessConfig struct {
 func (processConfig *ProcessConfig) getLogFilePath() string {
 	robinPath := config.GetRobinPath()
 	processLogsFolderPath := filepath.Join(robinPath, "logs", "processes")
-	processLogsPath := filepath.Join(processLogsFolderPath, string(processConfig.Id.Kind)+"-"+processConfig.Id.Source+"-"+processConfig.Id.Key+".log")
+	processLogsPath := filepath.Join(processLogsFolderPath, processConfig.Id.Source+"-"+processConfig.Id.Key+".log")
 	return processLogsPath
 }
 
@@ -73,6 +66,29 @@ type Process struct {
 	Command   string            `json:"command"`
 	Args      []string          `json:"args"`
 	Port      int               `json:"port"` // see docs in ProcessConfig
+}
+
+func InternalId(name string) ProcessId {
+	return ProcessId{
+		Source: "robin",
+		Key:    name,
+	}
+}
+
+func NewId(source string, name string) (ProcessId, error) {
+	if name == "robin" {
+		return ProcessId{}, fmt.Errorf("tried to use internal \"robin\" namespace")
+	}
+
+	if strings.HasPrefix(name, "@robinplatform/") {
+		return ProcessId{}, fmt.Errorf("tried to use internal \"@robinplatform/*\" namespace")
+
+	}
+
+	return ProcessId{
+		Source: source,
+		Key:    name,
+	}, nil
 }
 
 // TODO: Avoid logging entire Env
@@ -131,10 +147,6 @@ func (cfg *ProcessConfig) fillEmptyValues() error {
 
 	if cfg.Id.Source == "" {
 		return fmt.Errorf("cannot create process without a source")
-	}
-
-	if cfg.Id.Kind == "" {
-		cfg.Id.Kind = KindInternal
 	}
 
 	parentEnv := os.Environ()

--- a/backend/internal/process/process_test.go
+++ b/backend/internal/process/process_test.go
@@ -15,11 +15,7 @@ func TestSpawnProcess(t *testing.T) {
 		t.Fatalf("error loading DB: %s", err.Error())
 	}
 
-	id := ProcessId{
-		Kind:   KindInternal,
-		Source: "default",
-		Key:    "long",
-	}
+	id := InternalId("long")
 
 	_, err = manager.SpawnPath(ProcessConfig{
 		Id:      id,
@@ -49,11 +45,7 @@ func TestSpawnDead(t *testing.T) {
 		t.Fatalf("error loading DB: %s", err.Error())
 	}
 
-	id := ProcessId{
-		Kind:   KindInternal,
-		Source: "default",
-		Key:    "short",
-	}
+	id := InternalId("short")
 
 	_, err = manager.SpawnPath(ProcessConfig{
 		Id:      id,

--- a/backend/internal/project/config.go
+++ b/backend/internal/project/config.go
@@ -19,14 +19,18 @@ func GetProjectName() (string, error) {
 	return projectConfig.Name, err
 }
 
+func (projectConfig *RobinProjectConfig) GetProjectAlias() string {
+	// Remove all non alphanumeric characters from 'projectName' so it is a safe directory name
+	return pathRegex.ReplaceAllString(projectConfig.Name, "")
+}
+
 func GetProjectAlias() (string, error) {
-	projectName, err := GetProjectName()
+	projectConfig, err := LoadFromEnv()
 	if err != nil {
 		return "", err
 	}
 
-	// Remove all non alphanumeric characters from 'projectName' so it is a safe directory name
-	return pathRegex.ReplaceAllString(projectName, ""), nil
+	return projectConfig.GetProjectAlias(), nil
 }
 
 type RobinConfig struct {


### PR DESCRIPTION
- Added `GetProjectAlias()` as a method on project config
- Got rid of "ProcessKind"
- Added `process.InternalId()` and `process.NewId()` to create IDs which have certain invariants checked automatically