### PR TITLE
Factor out toolkit code

### DIFF
--- a/backend/cmd/cli/start.go
+++ b/backend/cmd/cli/start.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"runtime"
 
-	"robinplatform.dev/internal/compilerServer"
+	"robinplatform.dev/internal/compile/toolkit"
 	"robinplatform.dev/internal/config"
 	"robinplatform.dev/internal/project"
 	"robinplatform.dev/internal/server"
@@ -58,7 +58,7 @@ func (cmd *StartCommand) Run() error {
 	}
 
 	if cmd.forceStableToolkit {
-		compilerServer.DisableEmbeddedToolkit()
+		toolkit.DisableEmbeddedToolkit()
 	}
 
 	app := server.Server{

--- a/backend/internal/compile/toolkit/.gitignore
+++ b/backend/internal/compile/toolkit/.gitignore
@@ -1,0 +1,1 @@
+toolkit

--- a/backend/internal/compile/toolkit/toolkit.go
+++ b/backend/internal/compile/toolkit/toolkit.go
@@ -1,4 +1,4 @@
-package compilerServer
+package toolkit
 
 import (
 	"fmt"
@@ -12,22 +12,23 @@ import (
 	"robinplatform.dev/internal/project"
 )
 
+var logger = log.New("compile/toolkit")
 var toolkitInit = sync.Once{}
 
 func DisableEmbeddedToolkit() {
-	toolkitFS = nil
+	ToolkitFS = nil
 	logger.Warn("Embedded toolkit disabled", log.Ctx{})
 }
 
-func getToolkitPlugins(appConfig project.RobinAppConfig) []es.Plugin {
+func Plugins(appConfig project.RobinAppConfig) []es.Plugin {
 	toolkitInit.Do(initToolkit)
 
-	if toolkitFS == nil {
+	if ToolkitFS == nil {
 		return nil
 	}
 
 	resolver := resolve.Resolver{
-		FS: toolkitFS,
+		FS: ToolkitFS,
 	}
 
 	// The first set of plugins aim to resolve the toolkit source itself, and immediately give up on any

--- a/backend/internal/compile/toolkit/toolkit_dev.go
+++ b/backend/internal/compile/toolkit/toolkit_dev.go
@@ -1,6 +1,6 @@
 //go:build !prod
 
-package compilerServer
+package toolkit
 
 import (
 	"io/fs"
@@ -11,12 +11,12 @@ import (
 	"robinplatform.dev/internal/log"
 )
 
-var toolkitFS fs.FS
+var ToolkitFS fs.FS
 
 var initToolkit = func() {
 	_, filename, _, _ := runtime.Caller(0)
-	toolkitPath := filepath.Clean(filepath.Join(filepath.Dir(filename), "..", "..", "..", "toolkit"))
-	toolkitFS = os.DirFS(toolkitPath)
+	toolkitPath := filepath.Clean(filepath.Join(filepath.Dir(filename), "..", "..", "..", "..", "toolkit"))
+	ToolkitFS = os.DirFS(toolkitPath)
 	logger.Warn("Detected dev mode, using local toolkit", log.Ctx{
 		"path": toolkitPath,
 	})

--- a/backend/internal/compile/toolkit/toolkit_noop.go
+++ b/backend/internal/compile/toolkit/toolkit_noop.go
@@ -1,10 +1,10 @@
 //go:build !toolkit && prod
 
-package compilerServer
+package toolkit
 
 import (
 	"io/fs"
 )
 
-var toolkitFS fs.FS
+var ToolkitFS fs.FS
 var initToolkit = func() {}

--- a/backend/internal/compile/toolkit/toolkit_prod.go
+++ b/backend/internal/compile/toolkit/toolkit_prod.go
@@ -1,6 +1,6 @@
 //go:build toolkit && prod
 
-package compilerServer
+package toolkit
 
 import (
 	"embed"
@@ -21,7 +21,7 @@ func (e toolkitFsWrapper) Open(name string) (fs.File, error) {
 //go:generate rsync -rv --exclude=node_modules --exclude=robin.servers.json ../../../toolkit toolkit
 //go:embed all:toolkit
 var embedToolkitFS embed.FS
-var toolkitFS fs.FS = toolkitFsWrapper(embedToolkitFS)
+var ToolkitFS fs.FS = toolkitFsWrapper(embedToolkitFS)
 
 var initToolkit = func() {
 	logger.Debug("Using embedded toolkit", log.Ctx{})

--- a/backend/internal/compilerServer/.gitignore
+++ b/backend/internal/compilerServer/.gitignore
@@ -1,1 +1,0 @@
-toolkit

--- a/backend/internal/compilerServer/compiler.go
+++ b/backend/internal/compilerServer/compiler.go
@@ -17,6 +17,7 @@ import (
 
 	es "github.com/evanw/esbuild/pkg/api"
 	"robinplatform.dev/internal/compile/buildError"
+	"robinplatform.dev/internal/compile/toolkit"
 	"robinplatform.dev/internal/identity"
 	"robinplatform.dev/internal/log"
 	"robinplatform.dev/internal/process"
@@ -364,7 +365,7 @@ func (app *CompiledApp) buildClientJs() error {
 		Define:   app.getEnvConstants(),
 		Plugins: concat(
 			getExtractServerPlugins(appConfig, app),
-			getToolkitPlugins(appConfig),
+			toolkit.Plugins(appConfig),
 			[]es.Plugin{esbuildPluginLoadHttp},
 			getResolverPlugins(appConfig, pagePath),
 			getCssLoaderPlugins(appConfig),
@@ -471,7 +472,7 @@ func (app *CompiledApp) buildServerBundle() error {
 					},
 				},
 			},
-			getToolkitPlugins(appConfig),
+			toolkit.Plugins(appConfig),
 			getResolverPlugins(appConfig, pagePath),
 		),
 	})

--- a/backend/internal/compilerServer/daemon.go
+++ b/backend/internal/compilerServer/daemon.go
@@ -18,6 +18,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"robinplatform.dev/internal/compile/toolkit"
 	"robinplatform.dev/internal/config"
 	"robinplatform.dev/internal/log"
 	"robinplatform.dev/internal/process"
@@ -186,7 +187,7 @@ func (app *CompiledApp) setupJsDaemon(processConfig *process.ProcessConfig) erro
 	}
 
 	// Extract the daemon runner onto disk
-	daemonRunnerSourceFile, err := toolkitFS.Open("internal/app-daemon.js")
+	daemonRunnerSourceFile, err := toolkit.ToolkitFS.Open("internal/app-daemon.js")
 	if err != nil {
 		return fmt.Errorf("failed to start app server: could not find daemon runner: %w", err)
 	}


### PR DESCRIPTION
- Factor out the toolkit code into its own package; it's essentially isolated from the rest of the code, so it seems a perfect candidate for this sort of thing