### PR TITLE
Fix bug with server not having exported members

### DIFF
--- a/backend/internal/compilerServer/daemon.go
+++ b/backend/internal/compilerServer/daemon.go
@@ -93,6 +93,11 @@ func (app *CompiledApp) GetAppDir() (string, error) {
 }
 
 func (app *CompiledApp) setupJsDaemon(processConfig *process.ProcessConfig) error {
+	// Ensure that the client is always built first
+	if err := app.buildClient(); err != nil {
+		return err
+	}
+
 	appDir, err := app.GetAppDir()
 	if err != nil {
 		return fmt.Errorf("failed to start app server: %w", err)


### PR DESCRIPTION
Somehow, the server code was being built before the frontend. This meant that the server would not have the list of server exports necessary to actually respond to RPC calls properly.

I have truly no understanding of how this happened, but it did, and for now that is sufficient.