### PR TITLE
Allow `CreateTopic` RPC call to succeed when topic already exists

### DIFF
--- a/backend/internal/server/pubsub_rpc.go
+++ b/backend/internal/server/pubsub_rpc.go
@@ -45,6 +45,13 @@ var CreateTopic = AppsRpcMethod[CreateTopicInput, struct{}]{
 			Key:      req.Data.Key,
 		}
 
+		topic := getTopic(topicId)
+		if topic != nil {
+			// We've already created the topic; since app topics can't be closed right now,
+			// it is easier to simply do this additional hack.
+			return struct{}{}, nil
+		}
+
 		topic, err := pubsub.CreateTopic[any](&pubsub.Topics, topicId)
 		if err != nil {
 			return struct{}{}, Errorf(500, "%s", err.Error())


### PR DESCRIPTION
Right now, the topics associated with an app don't die when the app dies. To prevent the crash that this problem causes, this PR implements the band-aid of just making `CreateTopic` succeed when the topic already exists. However, we still ultimately gotta fix these band-aids eventually, because this band-aid exists because the app lifetime is difficult to query properly, because of ANOTHER bandaid.