### PR TITLE
Add more to Pogo planner, also add some more fixes to pubsub/streams

### DIFF
--- a/backend/internal/pubsub/pubsub.go
+++ b/backend/internal/pubsub/pubsub.go
@@ -385,7 +385,7 @@ func Subscribe[T any](r *Registry, id TopicId) (Subscription[T], error) {
 type TopicInfo struct {
 	Id              TopicId `json:"id"`
 	Closed          bool    `json:"closed"`
-	Counter         int32   `json:"counter"`
+	Counter         int32   `json:"counter"` // The ID of the next message
 	SubscriberCount int     `json:"subscriberCount"`
 }
 

--- a/example/my-ext/pogo/components/PageState.tsx
+++ b/example/my-ext/pogo/components/PageState.tsx
@@ -4,7 +4,7 @@ import { useSelectOption } from './EditableField';
 import { useRpcQuery } from '@robinplatform/toolkit/react/rpc';
 import { fetchDbRpc } from '../server/db.server';
 
-const DefaultPage = 'pokemon' as const;
+const DefaultPage = 'levelup' as const;
 
 // I'm not handling errors in this file, because... oh well. Whatever. Meh.
 const PageTypes = ['pokemon', 'planner', 'tables', 'levelup'] as const;

--- a/example/my-ext/pogo/components/PageState.tsx
+++ b/example/my-ext/pogo/components/PageState.tsx
@@ -4,7 +4,7 @@ import { useSelectOption } from './EditableField';
 import { useRpcQuery } from '@robinplatform/toolkit/react/rpc';
 import { fetchDbRpc } from '../server/db.server';
 
-const DefaultPage = 'levelup' as const;
+const DefaultPage = 'pokemon' as const;
 
 // I'm not handling errors in this file, because... oh well. Whatever. Meh.
 const PageTypes = ['pokemon', 'planner', 'tables', 'levelup'] as const;

--- a/example/my-ext/pogo/components/PageState.tsx
+++ b/example/my-ext/pogo/components/PageState.tsx
@@ -60,8 +60,8 @@ export function SelectPokemon() {
 			{pokemon.map((mon) => (
 				<option key={mon.id} value={mon.id}>
 					{mon.name
-						? `${mon.name} (${db?.pokedex?.[mon.pokemonId]?.name})`
-						: db?.pokedex?.[mon.pokemonId]?.name}
+						? `${mon.name} (${db?.pokedex?.[mon.pokedexId]?.name})`
+						: db?.pokedex?.[mon.pokedexId]?.name}
 				</option>
 			))}
 		</select>

--- a/example/my-ext/pogo/components/PokemonInfo.tsx
+++ b/example/my-ext/pogo/components/PokemonInfo.tsx
@@ -90,7 +90,7 @@ export function PokemonInfo({ pokemon }: { pokemon: Pokemon }) {
 	const { mutate: setName, isLoading: setNameLoading } =
 		useRpcMutation(setNameRpc);
 
-	const dexEntry = db?.pokedex[pokemon.pokemonId];
+	const dexEntry = db?.pokedex[pokemon.pokedexId];
 	if (!dexEntry) {
 		return null;
 	}
@@ -241,7 +241,7 @@ export function PokemonInfo({ pokemon }: { pokemon: Pokemon }) {
 						disabled={setEneryLoading}
 						value={dexEntry.megaEnergyAvailable}
 						setValue={(value) =>
-							setEnergy({ pokemonId: dexEntry.number, megaEnergy: value })
+							setEnergy({ pokedexId: dexEntry.number, megaEnergy: value })
 						}
 						parseFunc={(val) => {
 							const parsed = Number.parseInt(val);

--- a/example/my-ext/pogo/components/PokemonInfo.tsx
+++ b/example/my-ext/pogo/components/PokemonInfo.tsx
@@ -55,7 +55,7 @@ function EvolvePokemonButton({
 			<button
 				disabled={
 					megaEvolveLoading ||
-					isCurrentMega(db?.currentMega?.id, pokemon, now) ||
+					isCurrentMega(db?.mostRecentMega?.id, pokemon, now) ||
 					megaCost > dexEntry.megaEnergyAvailable
 				}
 				onClick={() => megaEvolve({ id: pokemon.id })}
@@ -69,7 +69,7 @@ function EvolvePokemonButton({
 function MegaIndicator({ pokemon }: { pokemon: Pokemon }) {
 	const { now } = useCurrentSecond();
 	const { data: db } = useRpcQuery(fetchDbRpc, {});
-	if (!isCurrentMega(db?.currentMega?.id, pokemon, now)) {
+	if (!isCurrentMega(db?.mostRecentMega?.id, pokemon, now)) {
 		return null;
 	}
 

--- a/example/my-ext/pogo/domain-utils.ts
+++ b/example/my-ext/pogo/domain-utils.ts
@@ -27,7 +27,9 @@ export const Pokemon = z.object({
 
 export type PlannedMega = z.infer<typeof PlannedMega>;
 export const PlannedMega = z.object({
-	date: z.string(),
+	id: z.string(), // UUID
+	date: z.string(), // ISO time string of the mega start time
+	pokemonId: z.string(), // ID of the pokemon to mega
 });
 
 export type PokemonMegaValues = {

--- a/example/my-ext/pogo/domain-utils.ts
+++ b/example/my-ext/pogo/domain-utils.ts
@@ -18,11 +18,16 @@ export const Species = z.object({
 export type Pokemon = z.infer<typeof Pokemon>;
 export const Pokemon = z.object({
 	id: z.string(),
-	pokemonId: z.number(),
+	pokedexId: z.number(),
 	name: z.string().optional(),
 	lastMegaStart: z.string(),
 	lastMegaEnd: z.string(),
 	megaCount: z.number(),
+});
+
+export type PlannedMega = z.infer<typeof PlannedMega>;
+export const PlannedMega = z.object({
+	date: z.string(),
 });
 
 export type PokemonMegaValues = {

--- a/example/my-ext/pogo/domain-utils.ts
+++ b/example/my-ext/pogo/domain-utils.ts
@@ -158,15 +158,15 @@ export function megaCostForTime(
 }
 
 export function isCurrentMega(
-	currentMega: string | undefined,
+	mostRecentMega: string | undefined,
 	pokemon: Pokemon,
 	now: Date,
 ) {
-	if (!currentMega) {
+	if (!mostRecentMega) {
 		return false;
 	}
 
-	if (currentMega !== pokemon.id) {
+	if (mostRecentMega !== pokemon.id) {
 		return false;
 	}
 

--- a/example/my-ext/pogo/math.ts
+++ b/example/my-ext/pogo/math.ts
@@ -19,3 +19,7 @@ export function dateString(d: Date): string {
 
 	return name;
 }
+
+export function uuid(s: string = ''): string {
+	return `${s}-${Math.random()}-${Math.random()}`;
+}

--- a/example/my-ext/pogo/math.ts
+++ b/example/my-ext/pogo/math.ts
@@ -10,3 +10,12 @@ export function lerp(a: number, b: number, t: number) {
 export function arrayOfN(n: number): number[] {
 	return [...Array.from(Array(n)).keys()];
 }
+
+// Creates a dateString
+export function dateString(d: Date): string {
+	const month = String(d.getMonth()).padStart(2, '0');
+	const day = String(d.getDate()).padStart(2, '0');
+	const name = `${d.getFullYear()}0${month}0${day}`;
+
+	return name;
+}

--- a/example/my-ext/pogo/pages/CostTables.tsx
+++ b/example/my-ext/pogo/pages/CostTables.tsx
@@ -146,7 +146,7 @@ export function CostTables() {
 	const { data: db } = useRpcQuery(fetchDbRpc, {});
 	const { pokemon: selectedMonId } = usePageState();
 	const selectedPokemon =
-		db?.pokedex?.[db.pokemon?.[selectedMonId ?? '']?.pokemonId ?? ''];
+		db?.pokedex?.[db.pokemon?.[selectedMonId ?? '']?.pokedexId ?? -1];
 
 	return (
 		<div className={'col full robin-rounded robin-gap robin-pad'}>

--- a/example/my-ext/pogo/pages/LevelUpPlanner.tsx
+++ b/example/my-ext/pogo/pages/LevelUpPlanner.tsx
@@ -1,4 +1,4 @@
-import { useRpcQuery } from '@robinplatform/toolkit/react/rpc';
+import { useRpcMutation, useRpcQuery } from '@robinplatform/toolkit/react/rpc';
 import React from 'react';
 import { ScrollWindow } from '../components/ScrollWindow';
 import {
@@ -10,6 +10,7 @@ import {
 	MegaEvolveEvent,
 	megaLevelPlanForPokemonRpc,
 } from '../server/planner.server';
+import { addPlannedEventRpc } from '../server/db.server';
 
 // Include cancel or not
 // Specify locks/planned actions
@@ -103,11 +104,36 @@ function DayBox({ children }: { children: React.ReactNode }) {
 	);
 }
 
+function AddEventButton({
+	pokemonId,
+	date,
+}: {
+	pokemonId: string;
+	date: Date;
+}) {
+	const { mutate: addPlannedEvents } = useRpcMutation(addPlannedEventRpc, {});
+
+	return (
+		<button
+			style={{
+				position: 'absolute',
+				left: '2rem',
+				top: '0',
+			}}
+			onClick={() =>
+				addPlannedEvents({ pokemonId, isoDate: date.toISOString() })
+			}
+		>
+			Mega
+		</button>
+	);
+}
+
 export function LevelUpPlanner() {
-	const { pokemon: selectedMonId } = usePageState();
+	const { pokemon: selectedMonId = '' } = usePageState();
 
 	const { data: days } = useRpcQuery(megaLevelPlanForPokemonRpc, {
-		id: selectedMonId ?? '',
+		id: selectedMonId,
 	});
 
 	return (
@@ -140,6 +166,10 @@ export function LevelUpPlanner() {
 						{eventsToday.map((e, index) => (
 							<EventText key={`${index}`} event={e} />
 						))}
+
+						{eventsToday.length === 0 && (
+							<AddEventButton pokemonId={selectedMonId} date={new Date(date)} />
+						)}
 					</DayBox>
 				))}
 			</ScrollWindow>

--- a/example/my-ext/pogo/pages/LevelUpPlanner.tsx
+++ b/example/my-ext/pogo/pages/LevelUpPlanner.tsx
@@ -12,16 +12,6 @@ import {
 } from '../server/planner.server';
 import { addPlannedEventRpc, deletePlannedEventRpc } from '../server/db.server';
 
-// Include cancel or not
-// Specify locks/planned actions
-
-// iterate forwards over lock points,
-// iterate backwards in time from each lock point
-// at the last lock point, iterate forwards in time
-
-// TODO: add something to allow for checking the cost of daily level-ups
-// TODO: add data that shows remaining mega energy
-
 function DateText({ date }: { date: Date }) {
 	return (
 		<div
@@ -81,7 +71,7 @@ function EventInfo({
 		);
 	}
 
-	const { id, megaEnergySpent } = event;
+	const { id, megaEnergySpent, megaEnergyAvailable } = event;
 
 	if (!id) {
 		return (
@@ -111,6 +101,7 @@ function EventInfo({
 		>
 			Evolve for {megaEnergySpent}
 			<button onClick={() => deletePlannedEvent({ id })}>X</button>
+			Remaining: {megaEnergyAvailable}
 		</div>
 	);
 }

--- a/example/my-ext/pogo/pages/PokemonManager.tsx
+++ b/example/my-ext/pogo/pages/PokemonManager.tsx
@@ -84,12 +84,14 @@ export function PokemonManager() {
 
 				<button
 					disabled={setDbIsLoading || dbIsLoading}
-					onClick={() =>
-						downloadObjectAsJson(
-							db,
-							`pogo-data-backup ${new Date().toISOString()}`,
-						)
-					}
+					onClick={() => {
+						const now = new Date();
+						const month = String(now.getMonth()).padStart(2, '0');
+						const day = String(now.getDate()).padStart(2, '0');
+						const name = `pogo-bkp ${now.getFullYear()}-${month}-${day}`;
+
+						downloadObjectAsJson(db, name);
+					}}
 				>
 					Download DB
 				</button>

--- a/example/my-ext/pogo/pages/PokemonManager.tsx
+++ b/example/my-ext/pogo/pages/PokemonManager.tsx
@@ -15,7 +15,7 @@ function SelectSpecies({
 	submit,
 	buttonText,
 }: {
-	submit: (data: { pokemonId: number }) => unknown;
+	submit: (data: { pokedexId: number }) => unknown;
 	buttonText: string;
 }) {
 	const { data: { pokedex = {} } = {} } = useRpcQuery(fetchDbRpc, {});
@@ -37,7 +37,7 @@ function SelectSpecies({
 
 			<button
 				disabled={!selected}
-				onClick={() => selected && submit({ pokemonId: selected.number })}
+				onClick={() => selected && submit({ pokedexId: selected.number })}
 			>
 				{buttonText}
 			</button>
@@ -57,7 +57,7 @@ function downloadObjectAsJson(exportObj: unknown, exportName: string) {
 	downloadAnchorNode.remove();
 }
 
-const Sorts = ['name', 'pokemonId', 'megaTime', 'megaLevelUp'] as const;
+const Sorts = ['name', 'pokedexId', 'megaTime', 'megaLevelUp'] as const;
 export function PokemonManager() {
 	const [sortIndex, setSortIndex] = React.useState<number>(0);
 	const sort = Sorts[sortIndex] ?? 'name';

--- a/example/my-ext/pogo/server/db.server.ts
+++ b/example/my-ext/pogo/server/db.server.ts
@@ -20,11 +20,7 @@ const PogoDb = z.object({
 	pokedex: z.record(z.coerce.number(), Species),
 	pokemon: z.record(z.string(), Pokemon),
 	evolvePlans: z.record(z.string(), z.array(PlannedMega)),
-	mostRecentMega: z
-		.object({
-			id: z.string(),
-		})
-		.optional(),
+	mostRecentMega: z.object({ id: z.string() }).optional(),
 });
 
 const DB_FILE = path.join(os.homedir(), '.a1liu-robin-pogo-db');

--- a/example/my-ext/pogo/server/planner.server.ts
+++ b/example/my-ext/pogo/server/planner.server.ts
@@ -92,7 +92,6 @@ export async function megaLevelPlanForPokemonRpc({
 		const planDate = new Date(plan.date);
 
 		const newState = computeEvolve(planDate, dexEntry, currentState);
-		console.log('plan', { plan, newState });
 		events.push({
 			date: plan.date,
 			id: plan.id,

--- a/example/my-ext/pogo/server/planner.server.ts
+++ b/example/my-ext/pogo/server/planner.server.ts
@@ -1,0 +1,66 @@
+import {
+	PokemonMegaValues,
+	Species,
+	Pokemon,
+	nextMegaDeadline,
+	computeEvolve,
+} from '../domain-utils';
+import { getDB } from './db.server';
+
+export type MegaEvolveEvent = PokemonMegaValues & {
+	date: string;
+};
+
+function naiveFreeMegaEvolve(
+	now: Date,
+	dexEntry: Species,
+	pokemon: Pick<Pokemon, 'lastMegaEnd' | 'lastMegaStart' | 'megaCount'>,
+): MegaEvolveEvent[] {
+	let { megaCount, lastMegaEnd, lastMegaStart } = pokemon;
+	const out: MegaEvolveEvent[] = [];
+
+	let currentState = { megaCount, lastMegaEnd, lastMegaStart };
+	while (currentState.megaCount < 30) {
+		const deadline = nextMegaDeadline(
+			currentState.megaCount,
+			new Date(currentState.lastMegaEnd),
+		);
+
+		// Move time forwards until the deadline; however, if the deadline is in the past,
+		// because its been a while since the last mega, don't accidentally go back in time.
+		now = new Date(Math.max(now.getTime(), deadline.getTime()));
+
+		const newState = computeEvolve(now, dexEntry, currentState);
+
+		out.push({
+			date: now.toISOString(),
+			...newState,
+		});
+
+		currentState = {
+			megaCount: newState.megaCount,
+			lastMegaEnd: newState.lastMegaEnd,
+			lastMegaStart: newState.lastMegaStart,
+		};
+	}
+
+	return out;
+}
+
+export async function megaLevelPlanForPokemonRpc({
+	id,
+}: {
+	id: string;
+}): Promise<MegaEvolveEvent[]> {
+	const db = getDB();
+	const pokemon = db.pokemon[id];
+	const dexEntry = db.pokedex[pokemon?.pokemonId ?? -1];
+
+	// rome-ignore lint/complexity/useSimplifiedLogicExpression: idiotic rule
+	if (!pokemon || !dexEntry) {
+		return [];
+	}
+
+	const now = new Date();
+	return naiveFreeMegaEvolve(now, dexEntry, pokemon);
+}

--- a/example/my-ext/pogo/server/planner.server.ts
+++ b/example/my-ext/pogo/server/planner.server.ts
@@ -60,7 +60,7 @@ export async function megaLevelPlanForPokemonRpc({
 }): Promise<PlannerDay[]> {
 	const db = getDB();
 	const pokemon = db.pokemon[id];
-	const dexEntry = db.pokedex[pokemon?.pokemonId ?? -1];
+	const dexEntry = db.pokedex[pokemon?.pokedexId ?? -1];
 
 	// rome-ignore lint/complexity/useSimplifiedLogicExpression: idiotic rule
 	if (!pokemon || !dexEntry) {

--- a/example/my-ext/pogo/server/planner.server.ts
+++ b/example/my-ext/pogo/server/planner.server.ts
@@ -71,8 +71,10 @@ export async function megaLevelPlanForPokemonRpc({
 	const plan = naiveFreeMegaEvolve(now, dexEntry, pokemon);
 
 	const timeToLastEvent =
-		new Date(plan[plan.length - 1].date).getTime() - now.getTime();
-	const daysToDisplay = Math.ceil(timeToLastEvent / DAY_MS) + 4;
+		plan.length === 0
+			? 0
+			: new Date(plan[plan.length - 1].date).getTime() - now.getTime();
+	const daysToDisplay = Math.max(0, Math.ceil(timeToLastEvent / DAY_MS)) + 4;
 
 	return arrayOfN(daysToDisplay)
 		.map((i) => new Date(Date.now() + (i - 2) * DAY_MS))

--- a/example/my-ext/pogo/server/planner.server.ts
+++ b/example/my-ext/pogo/server/planner.server.ts
@@ -1,3 +1,4 @@
+import { current } from 'immer';
 import {
 	PokemonMegaValues,
 	Species,
@@ -104,7 +105,9 @@ export async function megaLevelPlanForPokemonRpc({
 		};
 	}
 
-	events.push(...naiveFreeMegaEvolve(currentState.date, dexEntry, pokemon));
+	events.push(
+		...naiveFreeMegaEvolve(currentState.date, dexEntry, currentState),
+	);
 
 	const timeToLastEvent =
 		events.length === 0

--- a/example/my-ext/pogo/server/pogo.server.ts
+++ b/example/my-ext/pogo/server/pogo.server.ts
@@ -29,8 +29,8 @@ export async function refreshDexRpc() {
 }
 
 const compareNames = (db: PogoDb, a: Pokemon, b: Pokemon) => {
-	const aName = a.name ?? db.pokedex[a.pokemonId]?.name ?? '';
-	const bName = b.name ?? db.pokedex[b.pokemonId]?.name ?? '';
+	const aName = a.name ?? db.pokedex[a.pokedexId]?.name ?? '';
+	const bName = b.name ?? db.pokedex[b.pokedexId]?.name ?? '';
 
 	return aName.localeCompare(bName);
 };
@@ -51,7 +51,7 @@ const compareMegaTimes = (nowTime: number, a: Pokemon, b: Pokemon) => {
 export async function searchPokemonRpc({
 	sort,
 }: {
-	sort: 'name' | 'pokemonId' | 'megaTime' | 'megaLevelUp';
+	sort: 'name' | 'pokedexId' | 'megaTime' | 'megaLevelUp';
 }) {
 	const db = getDB();
 
@@ -62,9 +62,9 @@ export async function searchPokemonRpc({
 		case 'name':
 			out.sort((a, b) => compareNames(db, a, b));
 			break;
-		case 'pokemonId':
+		case 'pokedexId':
 			out.sort((a, b) => {
-				return a.pokemonId - b.pokemonId;
+				return a.pokedexId - b.pokedexId;
 			});
 			break;
 		case 'megaTime':

--- a/frontend/components/AppWindow.tsx
+++ b/frontend/components/AppWindow.tsx
@@ -150,7 +150,7 @@ function AppWindowContent({ id, setTitle }: AppWindowProps) {
 
 					<iframe
 						ref={iframeRef}
-						src={`http://localhost:9010/api/app-resources/${id}/base${subRoute}`}
+						src={`http://${window.location.hostname}:9010/api/app-resources/${id}/base${subRoute}`}
 						style={{ border: '0', flexGrow: 1, width: '100%', height: '100%' }}
 					/>
 				</>

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -136,7 +136,6 @@ function Topics() {
 			if (!selectedTopic) {
 				return prev;
 			}
-			console.log('selected', selectedTopic.id);
 			const prevArray: string[] = prev[selectedTopic.key] ?? [];
 			const message = JSON.stringify(packet);
 			return {

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -136,7 +136,7 @@ function Topics() {
 			if (!selectedTopic) {
 				return prev;
 			}
-
+			console.log('selected', selectedTopic.id);
 			const prevArray: string[] = prev[selectedTopic.key] ?? [];
 			const message = JSON.stringify(packet);
 			return {

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -136,6 +136,7 @@ function Topics() {
 			if (!selectedTopic) {
 				return prev;
 			}
+
 			const prevArray: string[] = prev[selectedTopic.key] ?? [];
 			const message = JSON.stringify(packet);
 			return {

--- a/toolkit/react/stream.tsx
+++ b/toolkit/react/stream.tsx
@@ -64,12 +64,10 @@ export function useTopicQuery<State, Output>({
 		},
 		reducer: (prev: StreamState, packet): StreamState => {
 			if (packet.kind === 'state') {
-				// The >= seems to be required. Sometimes we'll get two fetches in a row,
-				// and the first will cause the saved messages to be applied, only for the
-				// second fetch to arrive. If you use > instead of >=, the second fetch
-				// might overwrite the first, even though the state counter is literally
-				// the same.
-				if (prev.kind === 'state' && prev.counter >= packet.messageId) {
+				// The > allows new state to overwrite if it's up-to-date, but otherwise
+				// prevents fetches of now-stale data from interfering with the state of
+				// the topic.
+				if (prev.kind === 'state' && prev.counter > packet.messageId) {
 					return prev;
 				}
 

--- a/toolkit/react/stream.tsx
+++ b/toolkit/react/stream.tsx
@@ -184,7 +184,6 @@ export function useStreamMethod<State, Output>({
 			dispatch(res.data);
 		};
 
-		console.log('initialData', JSON.stringify(initialData));
 		stream.start(initialData).then(() => onConnRef.current?.());
 
 		return () => {

--- a/toolkit/react/stream.tsx
+++ b/toolkit/react/stream.tsx
@@ -77,17 +77,13 @@ export function useTopicQuery<State, Output>({
 				const state = seenMessages
 					.flatMap((msg) => {
 						const res = resultType.safeParse(msg.data);
-						if (res.success) {
-							return [res.data];
-						}
-
-						return [];
+						return res.success ? [res.data] : [];
 					})
 					.reduce((prev, data) => reducer(prev, data), packet.data as State);
 
-				const maxMessageId = seenMessages.reduce(
-					(max, msg) => Math.max(msg.messageId, max),
+				const maxMessageId = Math.max(
 					packet.messageId,
+					...seenMessages.map((m) => m.messageId),
 				);
 
 				return {

--- a/toolkit/stream.ts
+++ b/toolkit/stream.ts
@@ -8,7 +8,9 @@ async function getWs(): Promise<WebSocket> {
 
 	_ws = new Promise<WebSocket>((res) => (resolve = res));
 
-	const ws = new WebSocket('ws://localhost:9010/api/websocket');
+	const ws = new WebSocket(
+		`ws://${window.location.hostname}:9010/api/websocket`,
+	);
 	ws.onclose = (evt) => {
 		console.log('close', evt.code);
 	};


### PR DESCRIPTION
I'm only listing the Robin changes, because the pogo app is not part of Robin.

- Fixed error where a topic closure and an unsubscribe from `Subscriber[any]` at the same time would cause a double-`close` on a channel
- Switched a number of the URLs to `window.location.hostname` off of `localhost` so that you can do cute things like use robin remotely
- Fix weird race condition between multiple fetches in `useTopicQuery`