### PR TITLE
added compile command for profiling/tracing

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,3 +1,4 @@
 *.pprof
+*.trace
 *.test
 

--- a/backend/cmd/cli/cli.go
+++ b/backend/cmd/cli/cli.go
@@ -30,6 +30,7 @@ var (
 		&RemoveCommand{},
 		&CreateCommand{},
 		&VersionCommand{},
+		&CompileCommand{},
 	}
 )
 

--- a/backend/cmd/cli/compile.go
+++ b/backend/cmd/cli/compile.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"runtime/pprof"
+	"runtime/trace"
+
+	"robinplatform.dev/internal/compile/compileClient"
+	"robinplatform.dev/internal/compile/toolkit"
+	"robinplatform.dev/internal/config"
+	"robinplatform.dev/internal/httpcache"
+	"robinplatform.dev/internal/project"
+)
+
+type CompileCommand struct {
+	appId              string
+	enablePprof        bool
+	enableTrace        bool
+	forceStableToolkit bool
+}
+
+func (cmd *CompileCommand) Name() string {
+	return "compile"
+}
+
+func (cmd *CompileCommand) Description() string {
+	return "compile a robin app"
+}
+
+func (cmd *CompileCommand) Parse(flagSet *flag.FlagSet, args []string) error {
+	perfDefaultOn := config.GetReleaseChannel() == config.ReleaseChannelDev
+	flagSet.BoolVar(&cmd.enablePprof, "pprof", perfDefaultOn, "Enable profiling using runtime/pprof")
+	flagSet.BoolVar(&cmd.enableTrace, "trace", perfDefaultOn, "Enable tracing using runtime/trace")
+	flagSet.StringVar(&cmd.appId, "appId", "", "App ID")
+
+	if config.GetReleaseChannel() != config.ReleaseChannelStable {
+		flagSet.BoolVar(&cmd.forceStableToolkit, "use-stable-toolkit", false, "Force the use of the stable toolkit")
+	}
+
+	if err := flagSet.Parse(args); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (cmd *CompileCommand) Run() error {
+	_, err := project.LoadFromEnv()
+	if err != nil {
+		return err
+	}
+
+	if cmd.forceStableToolkit {
+		toolkit.DisableEmbeddedToolkit()
+	}
+
+	if cmd.enablePprof {
+		out, err := os.Create("./profile.pprof")
+		if err != nil {
+			return fmt.Errorf("failed to make profile file")
+		}
+
+		pprof.StartCPUProfile(out)
+		defer pprof.StopCPUProfile()
+	}
+
+	if cmd.enableTrace {
+		out, err := os.Create("./trace.trace")
+		if err != nil {
+			return fmt.Errorf("failed to make trace file")
+		}
+
+		trace.Start(out)
+		defer trace.Stop()
+	}
+
+	client, err := httpcache.NewClient(config.GetHttpCachePath(), 1024*1024*128)
+	if err != nil {
+		return err
+	}
+
+	_, err = compileClient.BuildClientBundle(compileClient.ClientJSInput{
+		AppId:           cmd.appId,
+		HttpClient:      client,
+		DefineConstants: make(map[string]string),
+	})
+	if err != nil {
+		return err
+	}
+
+	err = client.Save()
+
+	return err
+}

--- a/backend/internal/compilerServer/plugins.go
+++ b/backend/internal/compilerServer/plugins.go
@@ -1,8 +1,6 @@
 package compilerServer
 
 import (
-	"path/filepath"
-
 	"robinplatform.dev/internal/config"
 	"robinplatform.dev/internal/httpcache"
 	"robinplatform.dev/internal/log"
@@ -11,10 +9,8 @@ import (
 var httpClient httpcache.CacheClient
 
 func init() {
-	robinPath := config.GetRobinPath()
-
 	var err error
-	cacheFilename := filepath.Join(robinPath, "data", "http-cache.json")
+	cacheFilename := config.GetHttpCachePath()
 	httpClient, err = httpcache.NewClient(cacheFilename, 100*1024*1024)
 	if err != nil {
 		httpLogger := log.New("http")

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -24,3 +24,7 @@ func init() {
 func GetRobinPath() string {
 	return robinPath
 }
+
+func GetHttpCachePath() string {
+	return filepath.Join(robinPath, "data", "http-cache.json")
+}

--- a/backend/internal/project/app_config.go
+++ b/backend/internal/project/app_config.go
@@ -270,15 +270,21 @@ func LoadRobinAppById(appId string) (RobinAppConfig, error) {
 }
 
 func (projectConfig *RobinProjectConfig) LoadRobinAppById(appId string) (RobinAppConfig, error) {
-	apps, err := projectConfig.GetAllProjectApps()
-	if err != nil {
-		return RobinAppConfig{}, err
-	}
+	var loadErr error
+	for _, configPath := range projectConfig.Apps {
+		var app RobinAppConfig
+		if err := app.readRobinAppConfig(projectConfig, configPath); err != nil {
+			loadErr = err
+			continue
+		}
 
-	for _, app := range apps {
 		if app.Id == appId {
 			return app, nil
 		}
+	}
+
+	if loadErr != nil {
+		return RobinAppConfig{}, fmt.Errorf("failed to find app with id '%s': %w", appId, loadErr)
 	}
 
 	return RobinAppConfig{}, fmt.Errorf("failed to find app with id '%s'", appId)


### PR DESCRIPTION
I tried to profile/optimize the compilation steps a bit, and it did not work very well. This branch holds the work from that attempt that's re-usable, which is ended up just being the command I was using to collect profiling/tracing data.

On an unrelated note, here's what I found:
- Using incremental builds does not speed anything up, even though ~12% of the profile was in parsing
- Using minification speeds up over-the-network requests (which makes sense), but does not otherwise affect compilation speed much in either direction
- For some reason, esbuild really only ever gets 2 cores in the trace, even though it sorta looks like it could speed up quite a bit if it used 4 instead.
- Lots of time spent in codegen, and lots of time spent in parsing.