### PR TITLE
Hacky code to get pubsub to work when robin restarts

### DIFF
--- a/backend/internal/server/server.go
+++ b/backend/internal/server/server.go
@@ -82,6 +82,7 @@ func (server *Server) loadRpcMethods() {
 	server.router.GET("/api/websocket", wsHandler.WebsocketHandler(server))
 
 	SubscribeTopic.Register(wsHandler)
+	SubscribeAppTopic.Register(wsHandler)
 }
 
 func createErrorJs(errMessage string) string {

--- a/backend/internal/server/stream.go
+++ b/backend/internal/server/stream.go
@@ -251,8 +251,6 @@ func runMethod(method handler, rawReq *streamRequest) {
 
 	if err := method(rawReq); err != nil {
 		rawReq.SendRaw("error", err.Error())
-
-		return
 	}
 
 	rawReq.SendRaw("methodDone", nil)

--- a/example/pogo/pogo.tsx
+++ b/example/pogo/pogo.tsx
@@ -11,24 +11,8 @@ import { fetchDbRpc } from './server/db.server';
 import { z } from 'zod';
 import { useTopicQuery } from '@robinplatform/toolkit/react/stream';
 
-// "PoGo" is an abbreviation for Pokemon Go which is well-known in the
-// PoGo community.
-export function Pogo(): JSX.Element {
+function Page() {
 	const { page } = usePageState();
-
-	const { refetch } = useRpcQuery(fetchDbRpc, {});
-	useTopicQuery({
-		topicId: {
-			category: '/app-topics/pogo/pogo',
-			key: 'db',
-		},
-		resultType: z.object({}),
-		fetchState: () => Promise.resolve({ state: 0, counter: 0 }),
-		reducer: (a, _b) => {
-			refetch();
-			return a;
-		},
-	});
 
 	switch (page) {
 		case 'pokemon':
@@ -40,6 +24,36 @@ export function Pogo(): JSX.Element {
 		case 'levelup':
 			return <LevelUpPlanner />;
 	}
+}
+
+// "PoGo" is an abbreviation for Pokemon Go which is well-known in the
+// PoGo community.
+export function Pogo(): JSX.Element {
+	const [blarg, setBlarg] = React.useState('');
+
+	const { refetch } = useRpcQuery(fetchDbRpc, {});
+	useTopicQuery({
+		topicId: {
+			category: '/app-topics/pogo/pogo',
+			key: 'db',
+		},
+		resultType: z.object({}),
+		fetchState: () => {
+			setBlarg((blarg) => `${blarg}blah`);
+			return Promise.resolve({ state: 0, counter: 0 });
+		},
+		reducer: (a, _b) => {
+			refetch();
+			return a;
+		},
+	});
+
+	return (
+		<>
+			{blarg}
+			<Page />
+		</>
+	);
 }
 
 renderApp(<Pogo />);

--- a/example/pogo/pogo.tsx
+++ b/example/pogo/pogo.tsx
@@ -9,7 +9,7 @@ import { renderApp } from '@robinplatform/toolkit/react';
 import { useRpcQuery } from '@robinplatform/toolkit/react/rpc';
 import { fetchDbRpc } from './server/db.server';
 import { z } from 'zod';
-import { useTopicQuery } from '@robinplatform/toolkit/react/stream';
+import { useAppTopicQuery } from '@robinplatform/toolkit/react/stream';
 
 function Page() {
 	const { page } = usePageState();
@@ -32,11 +32,9 @@ export function Pogo(): JSX.Element {
 	const [blarg, setBlarg] = React.useState('');
 
 	const { refetch } = useRpcQuery(fetchDbRpc, {});
-	useTopicQuery({
-		topicId: {
-			category: '/app-topics/pogo/pogo',
-			key: 'db',
-		},
+	useAppTopicQuery({
+		category: ['pogo'],
+		key: 'db',
 		resultType: z.object({}),
 		fetchState: () => {
 			setBlarg((blarg) => `${blarg}blah`);

--- a/example/pogo/pogo.tsx
+++ b/example/pogo/pogo.tsx
@@ -29,15 +29,12 @@ function Page() {
 // "PoGo" is an abbreviation for Pokemon Go which is well-known in the
 // PoGo community.
 export function Pogo(): JSX.Element {
-	const [blarg, setBlarg] = React.useState('');
-
 	const { refetch } = useRpcQuery(fetchDbRpc, {});
 	useAppTopicQuery({
 		category: ['pogo'],
 		key: 'db',
 		resultType: z.object({}),
 		fetchState: () => {
-			setBlarg((blarg) => `${blarg}blah`);
 			return Promise.resolve({ state: 0, counter: 0 });
 		},
 		reducer: (a, _b) => {
@@ -48,7 +45,6 @@ export function Pogo(): JSX.Element {
 
 	return (
 		<>
-			{blarg}
 			<Page />
 		</>
 	);

--- a/example/pogo/server/db.server.ts
+++ b/example/pogo/server/db.server.ts
@@ -1,3 +1,5 @@
+/// <reference path="./lowdb.d.ts" />
+
 import { z } from 'zod';
 import * as fs from 'fs';
 import * as path from 'path';

--- a/toolkit/react/stream.tsx
+++ b/toolkit/react/stream.tsx
@@ -12,6 +12,39 @@ const PubsubData = z.object({
 	data: z.unknown(),
 });
 
+// Subscribe to an app topic and track the messages received in relation
+// to state.
+export function useAppTopicQuery<State, Output>({
+	appId = process.env.ROBIN_APP_ID,
+	category,
+	key,
+	fetchState,
+	reducer,
+	resultType,
+	skip,
+}: {
+	appId?: string;
+	resultType: z.Schema<Output>;
+	category?: string[];
+	key?: string;
+	fetchState: () => Promise<{ state: State; counter: number }>;
+	reducer: (s: State, o: Output) => State;
+	skip?: boolean;
+}) {
+	return useTopicQueryInternal<State, Output>({
+		methodName: 'SubscribeAppTopic',
+		data: {
+			appId,
+			category,
+			key,
+		},
+		skip: skip || !appId || !category || !key,
+		resultType,
+		reducer,
+		fetchState,
+	});
+}
+
 // Subscribe to a topic and track the messages received in relation
 // to state.
 export function useTopicQuery<State, Output>({
@@ -23,6 +56,33 @@ export function useTopicQuery<State, Output>({
 }: {
 	resultType: z.Schema<Output>;
 	topicId?: { category: string; key: string };
+	fetchState: () => Promise<{ state: State; counter: number }>;
+	reducer: (s: State, o: Output) => State;
+	skip?: boolean;
+}) {
+	return useTopicQueryInternal<State, Output>({
+		methodName: 'SubscribeTopic',
+		data: { id: topicId },
+		skip: skip || !topicId,
+		resultType,
+		reducer,
+		fetchState,
+	});
+}
+
+// Subscribe to a topic and track the messages received in relation
+// to state.
+function useTopicQueryInternal<State, Output>({
+	methodName,
+	data,
+	fetchState,
+	reducer,
+	resultType,
+	skip,
+}: {
+	methodName: string;
+	data: object;
+	resultType: z.Schema<Output>;
 	fetchState: () => Promise<{ state: State; counter: number }>;
 	reducer: (s: State, o: Output) => State;
 	skip?: boolean;
@@ -40,10 +100,10 @@ export function useTopicQuery<State, Output>({
 		  };
 
 	const { state, dispatch: rawDispatch } = useStreamMethod({
-		methodName: 'SubscribeTopic',
+		methodName,
 		resultType: PubsubData,
-		data: { id: topicId },
-		skip: skip || !topicId,
+		data,
+		skip: skip,
 		initialState: { kind: 'empty', seenMessages: [] },
 		onConnection: () => {
 			// This needs to run AFTER the connection completes so that there's no messages

--- a/toolkit/stream.ts
+++ b/toolkit/stream.ts
@@ -60,7 +60,7 @@ const getWs = (() => {
 			try {
 				switch (data.kind) {
 					case 'error':
-						stream.onerror(data.error, 'MethodError');
+						stream.onerror(data.data, 'MethodError');
 						break;
 
 					case 'methodDone':

--- a/toolkit/stream.ts
+++ b/toolkit/stream.ts
@@ -1,79 +1,125 @@
-let _ws: Promise<WebSocket> | null = null;
-let inFlight: Record<string, Stream> = {};
+const inFlight: Map<string, Stream> = new Map();
 
-async function getWs(): Promise<WebSocket> {
-	if (_ws !== null) return _ws;
+const getWs = (() => {
+	let _ws: Promise<WebSocket> | null = null;
 
-	let resolve: (ws: WebSocket) => void = () => {};
-
-	_ws = new Promise<WebSocket>((res) => (resolve = res));
-
-	const ws = new WebSocket(
-		`ws://${window.location.hostname}:9010/api/websocket`,
-	);
-	ws.onclose = (evt) => {
-		console.log('close', evt.code);
-	};
-
-	ws.onmessage = (evt) => {
-		const data = JSON.parse(evt.data);
-		const stream = inFlight[data.id];
-		if (!stream) {
-			return;
+	return (): Promise<WebSocket> => {
+		if (_ws !== null) {
+			return _ws;
 		}
 
-		switch (data.kind) {
-			case 'error':
-				stream.onerror(data.error);
-				break;
+		let resolveWs: (ws: WebSocket) => void = () => {};
 
-			case 'methodDone':
-				stream.onclose();
-				break;
+		const newWs = new Promise<WebSocket>((res) => (resolveWs = res));
+		_ws = newWs;
 
-			default:
-				stream.onmessage(data);
-		}
+		const ws = new WebSocket(
+			`ws://${window.location.hostname}:9010/api/websocket`,
+		);
+		ws.onclose = (evt) => {
+			console.log('close', evt.code);
+
+			// We only want to over-write if this specific websocket is the one that
+			// is currently active; otherwise, we can just die peacefully.
+			//
+			// It's possible that this will always be true, but at this very moment
+			// I think the extra condition to ensure no shenanigans is fine.
+			if (_ws === newWs) {
+				// Gain "exclusive write access" in a sense; nobody else will write to the
+				// `_ws` variable, and any time someone tries to get the websocket, they are
+				// instead directed to a promise that doesn't resolve until we say so.
+				// This must happen first, so that user-code called in stream.onclose
+				// doesn't get a handle to the old websocket instead of the new one.
+				let resolveWsCloseRetry: (ws: WebSocket) => void = () => {};
+				_ws = new Promise<WebSocket>((res) => (resolveWsCloseRetry = res));
+
+				// We spread before operating on the values, so that when calling the onclose handler,
+				// we don't modify the `inFlight` map while still iterating over it.
+				[...inFlight.values()].forEach((stream) =>
+					stream.onclose('WebsocketClosed'),
+				);
+
+				// Wait 2 seconds before retrying; then, before retrying, make sure to
+				// set `_ws` to null so that getWs() actually overwrites the variable again
+				// and we don't infinite loop.
+				setTimeout(() => {
+					_ws = null;
+					getWs().then(resolveWsCloseRetry);
+				}, 2000);
+			}
+		};
+
+		ws.onmessage = (evt) => {
+			const data = JSON.parse(evt.data);
+			const stream = inFlight.get(data.id);
+			if (!stream) {
+				return;
+			}
+
+			try {
+				switch (data.kind) {
+					case 'error':
+						stream.onerror(data.error, 'MethodError');
+						break;
+
+					case 'methodDone':
+						stream.onclose('MethodDone');
+						break;
+
+					default:
+						stream.onmessage(data);
+				}
+			} catch (e) {
+				stream.onerror(e, 'HandlerException');
+			}
+		};
+
+		ws.onerror = (evt) => {
+			console.error('Robin WS error', evt);
+		};
+
+		ws.onopen = () => {
+			resolveWs(ws);
+		};
+
+		return _ws;
 	};
+})();
 
-	ws.onerror = (evt) => {
-		console.error('Robin WS error', evt);
-	};
-
-	ws.onopen = () => {
-		resolve(ws);
-	};
-
-	return _ws;
-}
+type StreamCloseCause = 'CalledCloseMethod' | 'WebsocketClosed' | 'MethodDone';
+type StreamErrorSource = 'HandlerException' | 'MethodError';
 
 // This is a low-level primitive that can be used to implement higher-level
 // streaming requests.
 export class Stream {
 	private started = false;
 	private closed = false;
+	readonly id: string;
 
-	constructor(readonly method: string, readonly id: string) {}
+	constructor(readonly method: string) {
+		this.id = `${this.method}-${Math.random()}`;
+		this.onclose = () => {};
+	}
 
-	private closeHandler: () => void = () => {
-		this.closed = true;
-	};
+	private closeHandler: (cause: StreamCloseCause) => void = () => {};
 
 	onmessage: (a: unknown) => void = (a) => {
 		console.log(`Stream(${this.method}, ${this.id}) message:`, a);
 	};
-	onerror: (a: unknown) => void = (a) => {
-		console.error(`Stream(${this.method}, ${this.id}) error:`, a);
+	onerror: (a: unknown, source: StreamErrorSource) => void = (a, source) => {
+		console.error(`Stream(${this.method}, ${this.id}) ${source}:`, a);
 	};
 
-	set onclose(f: () => void) {
-		this.closeHandler = () => {
-			f();
+	set onclose(f: (cause: StreamCloseCause) => void) {
+		this.closeHandler = (cause: StreamCloseCause) => {
 			this.closed = true;
+			inFlight.delete(this.id);
+
+			f(cause);
 		};
 	}
 
-	get onclose(): () => void {
+	get onclose(): (cause: StreamCloseCause) => void {
 		return this.closeHandler;
 	}
 
@@ -83,7 +129,7 @@ export class Stream {
 		}
 
 		this.started = true;
-		inFlight[this.id] = this;
+		inFlight.set(this.id, this);
 
 		const ws = await getWs();
 		ws.send(
@@ -96,6 +142,16 @@ export class Stream {
 		);
 	}
 
+	// Don't like this name, but I'd rather be explicit about what this function actually does.
+	newStreamWithSameHandlers(): Stream {
+		const newStream = new Stream(this.method);
+		newStream.onmessage = this.onmessage;
+		newStream.onerror = this.onerror;
+		newStream.closeHandler = this.closeHandler;
+
+		return newStream;
+	}
+
 	async close() {
 		if (!this.started) {
 			throw new Error(`hasn't started yet`);
@@ -105,7 +161,7 @@ export class Stream {
 			return;
 		}
 
-		this.closed = true;
+		this.onclose('CalledCloseMethod');
 
 		const ws = await getWs();
 		ws.send(

--- a/toolkit/stream.ts
+++ b/toolkit/stream.ts
@@ -1,92 +1,89 @@
+let _ws: Promise<WebSocket> | null = null;
 const inFlight: Map<string, Stream> = new Map();
 
-const getWs = (() => {
-	let _ws: Promise<WebSocket> | null = null;
+async function getWs(): Promise<WebSocket> {
+	if (_ws !== null) {
+		return _ws;
+	}
 
-	return (): Promise<WebSocket> => {
-		if (_ws !== null) {
-			return _ws;
+	console.log('making new websocket');
+	let resolveWs: (ws: WebSocket) => void = () => {};
+
+	const newWs = new Promise<WebSocket>((res) => (resolveWs = res));
+	_ws = newWs;
+
+	const ws = new WebSocket(
+		`ws://${window.location.hostname}:9010/api/websocket`,
+	);
+	ws.onclose = (evt) => {
+		console.log('close', evt.code);
+
+		// We only want to over-write if this specific websocket is the one that
+		// is currently active; otherwise, we can just die peacefully.
+		//
+		// It's possible that this will always be true, but at this very moment
+		// I think the extra condition to ensure no shenanigans is fine.
+		if (_ws === newWs) {
+			// Gain "exclusive write access" in a sense; nobody else will write to the
+			// `_ws` variable, and any time someone tries to get the websocket, they are
+			// instead directed to a promise that doesn't resolve until we say so.
+			// This must happen first, so that user-code called in stream.onclose
+			// doesn't get a handle to the old websocket instead of the new one.
+			let resolveWsCloseRetry: (ws: WebSocket) => void = () => {};
+			_ws = new Promise<WebSocket>((res) => (resolveWsCloseRetry = res));
+
+			// We spread before operating on the values, so that when calling the onclose handler,
+			// we don't modify the `inFlight` map while still iterating over it.
+			[...inFlight.values()].forEach((stream) =>
+				stream.onclose('WebsocketClosed'),
+			);
+
+			// Wait 2 seconds before retrying; then, before retrying, make sure to
+			// set `_ws` to null so that getWs() actually overwrites the variable again
+			// and we don't infinite loop.
+			setTimeout(() => {
+				_ws = null;
+				getWs().then(resolveWsCloseRetry);
+			}, 2000);
+		}
+	};
+
+	ws.onmessage = (evt) => {
+		const data = JSON.parse(evt.data);
+		const stream = inFlight.get(data.id);
+		if (!stream) {
+			return;
 		}
 
-		console.log('making new websocket');
-		let resolveWs: (ws: WebSocket) => void = () => {};
+		try {
+			switch (data.kind) {
+				case 'error':
+					stream.onerror(data.data, 'MethodError');
+					break;
 
-		const newWs = new Promise<WebSocket>((res) => (resolveWs = res));
-		_ws = newWs;
+				case 'methodDone':
+					stream.onclose('MethodDone');
+					break;
 
-		const ws = new WebSocket(
-			`ws://${window.location.hostname}:9010/api/websocket`,
-		);
-		ws.onclose = (evt) => {
-			console.log('close', evt.code);
-
-			// We only want to over-write if this specific websocket is the one that
-			// is currently active; otherwise, we can just die peacefully.
-			//
-			// It's possible that this will always be true, but at this very moment
-			// I think the extra condition to ensure no shenanigans is fine.
-			if (_ws === newWs) {
-				// Gain "exclusive write access" in a sense; nobody else will write to the
-				// `_ws` variable, and any time someone tries to get the websocket, they are
-				// instead directed to a promise that doesn't resolve until we say so.
-				// This must happen first, so that user-code called in stream.onclose
-				// doesn't get a handle to the old websocket instead of the new one.
-				let resolveWsCloseRetry: (ws: WebSocket) => void = () => {};
-				_ws = new Promise<WebSocket>((res) => (resolveWsCloseRetry = res));
-
-				// We spread before operating on the values, so that when calling the onclose handler,
-				// we don't modify the `inFlight` map while still iterating over it.
-				[...inFlight.values()].forEach((stream) =>
-					stream.onclose('WebsocketClosed'),
-				);
-
-				// Wait 2 seconds before retrying; then, before retrying, make sure to
-				// set `_ws` to null so that getWs() actually overwrites the variable again
-				// and we don't infinite loop.
-				setTimeout(() => {
-					_ws = null;
-					getWs().then(resolveWsCloseRetry);
-				}, 2000);
+				default:
+					stream.onmessage(data);
 			}
-		};
-
-		ws.onmessage = (evt) => {
-			const data = JSON.parse(evt.data);
-			const stream = inFlight.get(data.id);
-			if (!stream) {
-				return;
-			}
-
-			try {
-				switch (data.kind) {
-					case 'error':
-						stream.onerror(data.data, 'MethodError');
-						break;
-
-					case 'methodDone':
-						stream.onclose('MethodDone');
-						break;
-
-					default:
-						stream.onmessage(data);
-				}
-			} catch (e) {
-				stream.onerror(e, 'HandlerException');
-			}
-		};
-
-		ws.onerror = (evt) => {
-			console.error('Robin WS error', evt);
-		};
-
-		ws.onopen = () => {
-			console.log('websocket opened');
-			resolveWs(ws);
-		};
-
-		return _ws;
+		} catch (e) {
+			stream.onerror(e, 'HandlerException');
+		}
 	};
-})();
+
+	ws.onerror = (evt) => {
+		console.error('Robin WS error', evt);
+	};
+
+	ws.onopen = () => {
+		console.log('websocket opened');
+		resolveWs(ws);
+	};
+
+	return _ws;
+}
 
 type StreamCloseCause = 'CalledCloseMethod' | 'WebsocketClosed' | 'MethodDone';
 type StreamErrorSource = 'HandlerException' | 'MethodError';

--- a/toolkit/stream.ts
+++ b/toolkit/stream.ts
@@ -8,6 +8,7 @@ const getWs = (() => {
 			return _ws;
 		}
 
+		console.log('making new websocket');
 		let resolveWs: (ws: WebSocket) => void = () => {};
 
 		const newWs = new Promise<WebSocket>((res) => (resolveWs = res));
@@ -79,6 +80,7 @@ const getWs = (() => {
 		};
 
 		ws.onopen = () => {
+			console.log('websocket opened');
 			resolveWs(ws);
 		};
 


### PR DESCRIPTION
Restarts break a number of things pubsub over RPC:
- Daemon dies
- Topics get destroyed
- Websocket gets closed

This PR aims to fix this behavior by doing the following:
- Ensure app restarts before subscription can finish
- Auto-retry websocket connection

It also adds some nicer/better error handling on the frontend side.

Unfortunately, dev-server restarts still break, because we don't have a way to tell whether a running app is old or new, so e.g. topics don't get re-created. This should *eventually* change, and everything will be good and simple. I hope.