### PR TITLE
Fix some resolution issues in Nightly

### DIFF
--- a/backend/internal/compile/toolkit/toolkit_prod.go
+++ b/backend/internal/compile/toolkit/toolkit_prod.go
@@ -18,7 +18,7 @@ func (e toolkitFsWrapper) Open(name string) (fs.File, error) {
 }
 
 //go:generate rm -rf toolkit
-//go:generate rsync -rv --exclude=node_modules --exclude=robin.servers.json ../../../../toolkit toolkit
+//go:generate rsync -rv --exclude=node_modules --exclude=robin.servers.json ../../../../toolkit/ toolkit
 //go:embed all:toolkit
 var embedToolkitFS embed.FS
 var ToolkitFS fs.FS = toolkitFsWrapper(embedToolkitFS)

--- a/example/pogo/components/PageState.tsx
+++ b/example/pogo/components/PageState.tsx
@@ -2,7 +2,6 @@ import { create } from 'zustand';
 import React from 'react';
 import { useRpcMutation, useRpcQuery } from '@robinplatform/toolkit/react/rpc';
 import { fetchDbRpc, setPageStateRpc } from '../server/db.server';
-import { set } from 'immer/dist/internal';
 
 const DefaultPage = 'pokemon' as const;
 

--- a/example/robin.json
+++ b/example/robin.json
@@ -5,6 +5,7 @@
 		"./bad-js-ext/robin.app.json",
 		"./failing-ext/robin.app.json",
 		"./pogo/robin.app.json",
+		"../../aliu/apps/pogo/robin.app.json",
 		"https://esm.sh/@robinplatform/app-example@0.0.11",
 		"../../server-manager/robin.app.json"
 	]

--- a/example/robin.json
+++ b/example/robin.json
@@ -5,7 +5,6 @@
 		"./bad-js-ext/robin.app.json",
 		"./failing-ext/robin.app.json",
 		"./pogo/robin.app.json",
-		"../../aliu/apps/pogo/robin.app.json",
 		"https://esm.sh/@robinplatform/app-example@0.0.11",
 		"../../server-manager/robin.app.json"
 	]

--- a/frontend/components/Sidebar.tsx
+++ b/frontend/components/Sidebar.tsx
@@ -48,9 +48,9 @@ export function Sidebar() {
 						<Link
 							href={`/app/${app.id}`}
 							className={cx(styles.sidebarLink, 'robin-pad', {
-								'robin-bg-dark-purple': window.location.pathname.startsWith(
-									`/app/${app.id}`,
-								),
+								'robin-bg-dark-purple':
+									window.location.pathname.startsWith(`/app/${app.id}/`) ||
+									window.location.pathname === `/app/${app.id}`,
 							})}
 						>
 							<span>


### PR DESCRIPTION
- rsync was adding an additional nesting of `toolkit`
- Fix false positive with App ID's that are prefixes of each other
- Remove unnecessary import that was causing resolution error in nightly