### PR TITLE
Switch to a 2 second timeout for the daemon

### DIFF
--- a/backend/internal/compilerServer/daemon.go
+++ b/backend/internal/compilerServer/daemon.go
@@ -58,13 +58,7 @@ func (app *CompiledApp) keepAlive() {
 			}
 		}
 
-		// TODO: This should be less frequent. I've set it to be higher right now
-		// to make development of robin apps easier/faster, but it should be lower.
-		if config.GetReleaseChannel() == "dev" {
-			time.Sleep(time.Second / 4)
-		} else {
-			time.Sleep(10 * time.Second)
-		}
+		time.Sleep(2 * time.Second)
 	}
 }
 

--- a/toolkit/internal/app-daemon.ts
+++ b/toolkit/internal/app-daemon.ts
@@ -105,10 +105,10 @@ async function main() {
 		});
 		console.log(`Started listening on :${process.env.PORT}`);
 
-		// Start a timer to automatically exit after 5 minutes of inactivity
+		// Start a timer to automatically exit after 5 seconds of inactivity
 		setInterval(() => {
-			if (Date.now() - lastRequest > 1000) {
-				console.log('No requests in 5 minutes, exiting');
+			if (Date.now() - lastRequest > 5000) {
+				console.log('No requests in 5 seconds, exiting');
 				process.exit(0);
 			}
 		}, 1000);


### PR DESCRIPTION
2 seconds seems to be a reasonable compromise, to not have daemons live indefinitely, but not have too-frequent pings.

Still need to write something to allow apps to run in watch mode.